### PR TITLE
The constructor in SQL Alchemy can only make use of a kwarg that

### DIFF
--- a/files/classes/submission.py
+++ b/files/classes/submission.py
@@ -38,6 +38,7 @@ class Submission(Base):
 	comment_count = Column(Integer, default=0)
 	is_approved = Column(Integer, ForeignKey("users.id"))
 	over_18 = Column(Boolean, default=False)
+	new = Column(Boolean, default=True)
 	is_bot = Column(Boolean, default=False)
 	upvotes = Column(Integer, default=1)
 	downvotes = Column(Integer, default=0)


### PR DESCRIPTION
already exists in the class. "New" was added as a kwarg in the submit_post
method in posts.py, but a matching attribute did not exist in the submissions
class in submission.py. They didn't match, so it feel over.
In this commit I simply added the new attribute to the submission class so they
match and it doesn't fall over.