### PR TITLE
Added tabindex values to inputs on register page

### DIFF
--- a/files/templates/sign_up.html
+++ b/files/templates/sign_up.html
@@ -84,7 +84,7 @@
 												<label for="username-register" class="mt-3">Username</label>
 
 												<input autocomplete="off" class="form-control" id="username-register"
-												aria-describedby="usernameHelpRegister" type="text" name="username" pattern="[a-zA-Z0-9_\-]{3,25}" min="3" max="25" required="">
+												aria-describedby="usernameHelpRegister" type="text" name="username" pattern="[a-zA-Z0-9_\-]{3,25}" min="3" max="25" required autofocus tabindex="1">
 												<small id="usernameHelpRegister"></small>
 
 												<label for="email-register" class="mt-3">Email Address</label>
@@ -92,12 +92,12 @@
 												<small class="d-inline-block text-muted ml-1">(optional)</small>
 
 												<input style="background-color: var(--gray-800)" autocomplete="off" class="form-control" id="email-register"
-												aria-describedby="emailHelpRegister" type="email" pattern='([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+' name="email" readonly onfocus="if (this.hasAttribute('readonly')) {this.removeAttribute('readonly');this.blur();this.focus()}">
+												aria-describedby="emailHelpRegister" type="email" pattern='([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+' name="email" tabindex="2">
 
 												<label for="password-register" class="mt-3">Password</label>
 
 												<input autocomplete="off" class="form-control" id="password-register"
-												aria-describedby="passwordHelpReigster" type="password" name="password" required="">
+												aria-describedby="passwordHelpReigster" type="password" name="password" required tabindex="4">
 												<small id="passwordHelpRegister" class="form-text font-weight-bold text-muted d-none mt-1">Minimum of 8
 														characters
 												required.</small>
@@ -108,20 +108,20 @@
 
 												<input autocomplete="off" class="form-control" id="password_confirm"
 												aria-describedby="passwordConfirmHelp" type="password" name="password_confirm"
-												required="">
+												required tabindex="5">
 												<div class="custom-control custom-checkbox mt-4">
-														<input autocomplete="off" type="checkbox" class="custom-control-input" id="termsCheck" required>
-														<label class="custom-control-label terms" for="termsCheck">I accept the <a href="/sidebar">rules</a></label>
+														<input autocomplete="off" type="checkbox" class="custom-control-input" id="termsCheck" required tabindex="6">
+														<label class="custom-control-label terms" for="termsCheck">I accept the <a href="/sidebar" tabindex="8">rules</a></label>
 												</div>
 
 												{% if hcaptcha %}
 													<div class="h-captcha" data-sitekey="{{hcaptcha}}"></div>
 												{% endif %}
 
-												<button class="btn btn-primary login w-100 mt-3" id="register_button">Register</button>
+												<button class="btn btn-primary login w-100 mt-3" id="register_button" tabindex="7">Register</button>
 
 												<div class="text-center text-muted text-small mt-2 mb-0">
-																Already have an account? <a href="/login{{'?redirect='+redirect if redirect else ''}}" class="font-weight-bold toggle-login">Log in</a>
+																Already have an account? <a href="/login{{'?redirect='+redirect if redirect else ''}}" class="font-weight-bold toggle-login" tabindex="9">Log in</a>
 												</div>
 
 											</form>


### PR DESCRIPTION
This fixes the issue I was seeing with the register page where tabbing to the next field doesn't work. I removed a snippet of javascript that was trying to make the email field readonly until the user deliberately clicks on it. 

I'm not sure if that was what we want, but if not I can roll that back. I think it was there for style reasons more than anything else- the field is grayed out, which implies it's optional, I suppose.