### PR TITLE
Fix profile image performance

### DIFF
--- a/files/assets/js/marked.custom.js
+++ b/files/assets/js/marked.custom.js
@@ -29,6 +29,30 @@ marked.use({
 				const content = this.parser.parseInline(token.tokens);
 				return `<span class="spoiler">${content}</span>`;
 			}
+		},
+		{
+			name: 'mention',
+			level: 'inline',
+			start: function(src){
+				const match = src.match(/@[a-zA-Z0-9_\-]+/);
+				return match != null ? match.index : -1;
+			},
+			tokenizer: function(src) {
+				const rule  = /^@[a-zA-Z0-9_\-]+/;
+				const match = rule.exec(src);
+				if(match){
+					return {
+						type: 'mention',
+						raw:  match[0],
+						text: match[0].trim().slice(1),
+						tokens: []
+					};
+				}
+			},
+			renderer(token) {
+				const u = token.raw;
+				return `<a href="/${u}"><img src="/${u}/pic" class="pp20"> ${u}</a>`;
+			}
 		}
 	]
 });

--- a/files/helpers/get.py
+++ b/files/helpers/get.py
@@ -63,6 +63,29 @@ def get_user(username, v=None, graceful=False):
 
 	return user
 
+def get_users(usernames, v=None, graceful=False):
+	if not usernames:
+		if not graceful: abort(404)
+		else: return []
+
+	def clean(n):
+		return n.replace('\\', '').replace('_', '\_').replace('%', '').strip()
+
+	usernames = [ clean(n) for n in usernames ]
+
+	users = g.db.query(User).filter(
+		or_(
+			User.username == any_(usernames),
+			User.original_username == any_(usernames)
+			)
+		).all()
+
+	if not users:
+		if not graceful: abort(404)
+		else: return []
+
+	return users
+
 def get_account(id, v=None):
 
 	try: id = int(id)

--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -154,18 +154,12 @@ def sanitize(sanitized, alert=False, comment=False, edit=False):
 				sanitized = sanitized.replace(i.group(0), f'''<p><a href="/id/{u.id}"><img loading="lazy" src="/pp/{u.id}">@{u.username}</a>''')
 	else:
 		sanitized = reddit_regex.sub(r'\1<a href="https://old.reddit.com/\2" rel="nofollow noopener noreferrer">/\2</a>', sanitized)
-
 		sanitized = sub_regex.sub(r'\1<a href="/\2">/\2</a>', sanitized)
 
-		captured = []
 		for i in mention_regex.finditer(sanitized):
-			if i.group(0) in captured: continue
-			captured.append(i.group(0))
-
 			u = get_user(i.group(2), graceful=True)
-
 			if u and (not (g.v and g.v.any_block_exists(u)) or g.v.admin_level > 1):
-				sanitized = sanitized.replace(i.group(0), f'''{i.group(1)}<a href="/id/{u.id}"><img loading="lazy" src="/pp/{u.id}">@{u.username}</a>''')
+				sanitized = sanitized.replace(i.group(0), f'''{i.group(1)}<a href="/id/{u.id}"><img loading="lazy" src="/pp/{u.id}">@{u.username}</a>''', 1)
 
 
 	sanitized = imgur_regex.sub(r'\1_d.webp?maxwidth=9999&fidelity=high', sanitized)

--- a/files/templates/sign_up.html
+++ b/files/templates/sign_up.html
@@ -111,7 +111,7 @@
 												required tabindex="5">
 												<div class="custom-control custom-checkbox mt-4">
 														<input autocomplete="off" type="checkbox" class="custom-control-input" id="termsCheck" required tabindex="6">
-														<label class="custom-control-label terms" for="termsCheck">I accept the <a href="/sidebar" tabindex="8">rules</a></label>
+														<label class="custom-control-label terms" for="termsCheck">I accept the <a href="/rules" tabindex="8">rules</a></label>
 												</div>
 
 												{% if hcaptcha %}

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -12,8 +12,6 @@
 		<meta name="author" content="">
 		<link rel="icon" type="image/png" href="/assets/images/{{SITE_NAME}}/icon.webp?v=1015">
 
-		{% set cc='Country Club' %}
-
 		{% block title %}
 		<title>Create a post - {{SITE_NAME}}</title>
 		{% endblock %}
@@ -131,16 +129,6 @@
 												<div class="custom-control custom-checkbox">
 														<input onchange='draft(this);' autocomplete="off" type="checkbox" class="custom-control-input" id="private" name="private">
 														<label class="custom-control-label" for="private">Draft</label>
-												</div>
-
-												<div class="custom-control custom-checkbox">
-													<input autocomplete="off" type="checkbox" class="custom-control-input" id="club" name="club">
-													<label class="custom-control-label" for="club">{{CC_TITLE}} thread</label>
-												</div>
-
-												<div class="custom-control custom-checkbox">
-														<input onchange='draft(this);' autocomplete="off" type="checkbox" class="custom-control-input" id="ghost" name="ghost" {% if v.coins < 100 %}disabled{% endif %}>
-														<label class="custom-control-label" for="ghost">Ghost Thread (cost: 100 coins)</label>
 												</div>
 
 												<pre>

--- a/schema.sql
+++ b/schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE public.submissions (
     body character varying(20000),
     body_html character varying(40000),
     embed_url character varying(1500),
+    filter_state character varying(30) NOT NULL,
     ban_reason character varying(25),
     title_html character varying(1500) NOT NULL,
     realupvotes integer,
@@ -370,11 +371,31 @@ CREATE TABLE public.exiles (
 --
 
 CREATE TABLE public.flags (
+    id integer NOT NULL,
     user_id integer NOT NULL,
     post_id integer NOT NULL,
     reason character varying(350),
     created_utc integer NOT NULL
 );
+
+--
+-- Name: flags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.flags_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: flags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.flags_id_seq OWNED BY public.flags.id;
 
 
 --
@@ -735,6 +756,12 @@ ALTER TABLE ONLY public.usernotes ALTER COLUMN id SET DEFAULT nextval('public.us
 --
 
 ALTER TABLE ONLY public.comments ALTER COLUMN id SET DEFAULT nextval('public.comments_id_seq'::regclass);
+
+--
+-- Name: flags id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.flags ALTER COLUMN id SET DEFAULT nextval('public.flags_id_seq'::regclass);
 
 
 --

--- a/schema.sql
+++ b/schema.sql
@@ -93,7 +93,6 @@ CREATE TABLE public.submissions (
     body character varying(20000),
     body_html character varying(40000),
     embed_url character varying(1500),
-    filter_state character varying(30) NOT NULL,
     ban_reason character varying(25),
     title_html character varying(1500) NOT NULL,
     realupvotes integer,
@@ -371,31 +370,11 @@ CREATE TABLE public.exiles (
 --
 
 CREATE TABLE public.flags (
-    id integer NOT NULL,
     user_id integer NOT NULL,
     post_id integer NOT NULL,
     reason character varying(350),
     created_utc integer NOT NULL
 );
-
---
--- Name: flags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.flags_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: flags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.flags_id_seq OWNED BY public.flags.id;
 
 
 --
@@ -756,12 +735,6 @@ ALTER TABLE ONLY public.usernotes ALTER COLUMN id SET DEFAULT nextval('public.us
 --
 
 ALTER TABLE ONLY public.comments ALTER COLUMN id SET DEFAULT nextval('public.comments_id_seq'::regclass);
-
---
--- Name: flags id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.flags ALTER COLUMN id SET DEFAULT nextval('public.flags_id_seq'::regclass);
 
 
 --


### PR DESCRIPTION
This isn't a perfect fix, but it seems to cut the CPU usage in half and makes the site a lot more responsive.

* Batched user queries for mentions on submission in `sanitize.py`
* Added caching to the `/pp/<id>` route
* Added caching to the `/@<username>/pic` (for mention previews)
* Rather than a redirect, `/pp/<id>` now directly loads and returns the image
* Removed redirect in `/@<username>/pic` as well
* Added upstream fix provided by @TLSM ([this issue](https://github.com/Aevann1/rDrama/commit/0d9c40f4c903aa9e52149c997620d3ad4447d85d))
* Added @mention support to the markdown preview