### PR TITLE
Fixed reply-twice bug on submission page

### DIFF
--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -246,8 +246,6 @@ function post_comment(fullname){
 			let comments = document.getElementById('comment-section');
 			let comment = data["comment"].replace(/data-src/g, 'src').replace(/data-cfsrc/g, 'src').replace(/style="display:none;visibility:hidden;"/g, '');
 
-			// clear out the text-center classes etc. used by placeholder
-			comments.className = 'comment-section';
 			comments.innerHTML = comment + comments.innerHTML;
 
 			bs_trigger(commentForm);
@@ -255,6 +253,8 @@ function post_comment(fullname){
 			// remove the placeholder if it exists
 			let placeholder = document.getElementById("placeholder-comment");
 			if(placeholder){
+				// clear out the text-center classes etc.
+				comments.className = 'comment-section';
 				placeholder.parentNode.removeChild(placeholder);
 			}
 		}

--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -241,9 +241,18 @@ function post_comment(fullname){
 		catch(e) {console.log(e)}
 		if (data && data["comment"]) {
 			commentForm=document.getElementById('comment-form-space-'+fullname);
-			commentForm.innerHTML = data["comment"].replace(/data-src/g, 'src').replace(/data-cfsrc/g, 'src').replace(/style="display:none;visibility:hidden;"/g, '');
+
+			// dynamically insert comment into the comments section at the top
+			let comments = document.getElementById('comment-section');
+			let comment = data["comment"].replace(/data-src/g, 'src').replace(/data-cfsrc/g, 'src').replace(/style="display:none;visibility:hidden;"/g, '');
+
+			// clear out the text-center classes etc. used by placeholder
+			comments.className = 'comment-section';
+			comments.innerHTML = comment + comments.innerHTML;
+
 			bs_trigger(commentForm);
 
+			// remove the placeholder if it exists
 			let placeholder = document.getElementById("placeholder-comment");
 			if(placeholder){
 				placeholder.parentNode.removeChild(placeholder);

--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -240,10 +240,12 @@ function post_comment(fullname){
 		try {data = JSON.parse(xhr.response)}
 		catch(e) {console.log(e)}
 		if (data && data["comment"]) {
-			commentForm=document.getElementById('comment-form-space-'+fullname);
+			let id = fullname.split('_')[1];
+			let name = 'comment-form-space-' + fullname;
+			commentForm = document.getElementById(name);
 
-			// dynamically insert comment into the comments section at the top
-			let comments = document.getElementById('comment-section');
+			// dynamically insert comment into the comments section of the current comment/post
+			let comments = document.getElementById('replies-of-' + id);
 			let comment = data["comment"].replace(/data-src/g, 'src').replace(/data-cfsrc/g, 'src').replace(/style="display:none;visibility:hidden;"/g, '');
 
 			comments.innerHTML = comment + comments.innerHTML;
@@ -254,7 +256,8 @@ function post_comment(fullname){
 			let placeholder = document.getElementById("placeholder-comment");
 			if(placeholder){
 				// clear out the text-center classes etc.
-				comments.className = 'comment-section';
+				comments.classList.remove('text-center');
+				comments.classList.remove('py-7');
 				placeholder.parentNode.removeChild(placeholder);
 			}
 		}

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -533,6 +533,9 @@
 			<textarea autocomplete="off" class="d-none card border my-2 p-3 comment-box form-control rounded" id="markdown-{{c.id}}" readonly>{{c.body.strip()}}</textarea> 
 		{% endif %}
 
+		{% if ajax %}
+		{{ render_replies }}
+		{% endif %}
 
 		<div id="reply-to-{{c.id}}" class="d-none">
 			<div id="comment-form-space-{{c.fullname}}" class="comment-write collapsed child">
@@ -603,6 +606,9 @@
 				</div>
 			</div>
 		{% endif %}
+
+	{% else %}
+	<div id="replies-of-{{c.id}}"></div>
 	{% endif %}
 	</div>
 

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -533,9 +533,6 @@
 			<textarea autocomplete="off" class="d-none card border my-2 p-3 comment-box form-control rounded" id="markdown-{{c.id}}" readonly>{{c.body.strip()}}</textarea> 
 		{% endif %}
 
-		{% if ajax %}
-		{{ render_replies }}
-		{% endif %}
 
 		<div id="reply-to-{{c.id}}" class="d-none">
 			<div id="comment-form-space-{{c.fullname}}" class="comment-write collapsed child">
@@ -606,7 +603,6 @@
 				</div>
 			</div>
 		{% endif %}
-
 	{% else %}
 	<div id="replies-of-{{c.id}}"></div>
 	{% endif %}

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -516,7 +516,7 @@
 	{% endif %}
 
 	{% if p.replies %}
-	<div class="comment-section" id="comment-section">
+	<div class="comment-section" id="replies-of-{{p.id}}">
 	{% with comments=p.replies %}
 		{% include "comments.html" %}
 	{% endwith %}
@@ -559,7 +559,7 @@
 {% endif %}
 
 {% elif not p.replies and p.deleted_utc == 0 %}
-	<div class="comment-section text-center py-7" id="comment-section">
+	<div class="comment-section text-center py-7" id="replies-of-{{p.id}}">
 		<div class="row no-gutters" id="placeholder-comment">	
 			<div class="col">			
 				<span class="fa-stack fa-2x text-muted mb-4">

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -516,7 +516,7 @@
 	{% endif %}
 
 	{% if p.replies %}
-	<div class="comment-section">
+	<div class="comment-section" id="comment-section">
 	{% with comments=p.replies %}
 		{% include "comments.html" %}
 	{% endwith %}
@@ -559,7 +559,7 @@
 {% endif %}
 
 {% elif not p.replies and p.deleted_utc == 0 %}
-	<div class="comment-section text-center py-7">
+	<div class="comment-section text-center py-7" id="comment-section">
 		<div class="row no-gutters" id="placeholder-comment">	
 			<div class="col">			
 				<span class="fa-stack fa-2x text-muted mb-4">


### PR DESCRIPTION
Fixed the reply-twice issue by inserting new comments into the top of the comment section instead of replacing the reply form with them. I also had to remove some classes on the comment section that are only there when the placeholder is in the page (text center class etc.)