### PR TITLE
Hide vote details from non-admins.

### DIFF
--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -72,7 +72,7 @@ def leaderboard_thread():
 gevent.spawn(leaderboard_thread())
 
 @app.get("/@<username>/upvoters/<uid>/posts")
-@auth_required
+@admin_level_required(3)
 def upvoters_posts(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -93,7 +93,7 @@ def upvoters_posts(v, username, uid):
 
 
 @app.get("/@<username>/upvoters/<uid>/comments")
-@auth_required
+@admin_level_required(3)
 def upvoters_comments(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -114,7 +114,7 @@ def upvoters_comments(v, username, uid):
 
 
 @app.get("/@<username>/downvoters/<uid>/posts")
-@auth_required
+@admin_level_required(3)
 def downvoters_posts(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -135,7 +135,7 @@ def downvoters_posts(v, username, uid):
 
 
 @app.get("/@<username>/downvoters/<uid>/comments")
-@auth_required
+@admin_level_required(3)
 def downvoters_comments(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -159,7 +159,7 @@ def downvoters_comments(v, username, uid):
 
 
 @app.get("/@<username>/upvoting/<uid>/posts")
-@auth_required
+@admin_level_required(3)
 def upvoting_posts(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -180,7 +180,7 @@ def upvoting_posts(v, username, uid):
 
 
 @app.get("/@<username>/upvoting/<uid>/comments")
-@auth_required
+@admin_level_required(3)
 def upvoting_comments(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -201,7 +201,7 @@ def upvoting_comments(v, username, uid):
 
 
 @app.get("/@<username>/downvoting/<uid>/posts")
-@auth_required
+@admin_level_required(3)
 def downvoting_posts(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -222,7 +222,7 @@ def downvoting_posts(v, username, uid):
 
 
 @app.get("/@<username>/downvoting/<uid>/comments")
-@auth_required
+@admin_level_required(3)
 def downvoting_comments(v, username, uid):
 	u = get_user(username)
 	if u.is_private and v.id != u.id: abort(403)
@@ -254,7 +254,7 @@ def grassed(v):
 
 
 @app.get("/@<username>/upvoters")
-@auth_required
+@admin_level_required(3)
 def upvoters(v, username):
 	id = get_user(username).id
 
@@ -280,7 +280,7 @@ def upvoters(v, username):
 
 
 @app.get("/@<username>/downvoters")
-@auth_required
+@admin_level_required(3)
 def downvoters(v, username):
 	id = get_user(username).id
 
@@ -304,7 +304,7 @@ def downvoters(v, username):
 	return render_template("voters.html", v=v, users=users[:25], pos=pos, name='Down', name2=f'Who downvotes @{username}')
 
 @app.get("/@<username>/upvoting")
-@auth_required
+@admin_level_required(3)
 def upvoting(v, username):
 	id = get_user(username).id
 
@@ -328,7 +328,7 @@ def upvoting(v, username):
 	return render_template("voters.html", v=v, users=users[:25], pos=pos, name='Up', name2=f'Who @{username} upvotes')
 
 @app.get("/@<username>/downvoting")
-@auth_required
+@admin_level_required(3)
 def downvoting(v, username):
 	id = get_user(username).id
 

--- a/files/routes/votes.py
+++ b/files/routes/votes.py
@@ -8,7 +8,7 @@ from os import environ
 
 @app.get("/votes")
 @limiter.limit("5/second;60/minute;200/hour;1000/day")
-@auth_required
+@admin_level_required(3)
 def admin_vote_info_get(v):
 	link = request.values.get("link")
 	if not link: return render_template("votes.html", v=v)

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -429,7 +429,7 @@
 						
 						{% endif %}
 						
-						{% if not c.ghost or v.id == AEVANN_ID %}<a href="/votes?link={{c.fullname}}" class="btn caction nobackground px-1 text-muted"><i class="fas fa-arrows-v"></i>Votes</a>{% endif %}
+						{% if v.admin_level >= 2 %}<a href="/votes?link={{c.fullname}}" class="btn caction nobackground px-1 text-muted"><i class="fas fa-arrows-v"></i>Votes</a>{% endif %}
 						
 						<a class="btn caction nobackground px-1 text-muted" href="{{c.permalink}}"><i class="fas fa-book-open"></i>Context</a>
 
@@ -621,7 +621,7 @@
 			<div class="modal-body">
 				<ul class="list-group comment-actions">
 
-					{% if not c.ghost or v.id == AEVANN_ID %}<a href="/votes?link={{c.fullname}}"><li class="list-group-item"><i class="fas fa-arrows-v mr-2"></i>Votes</li></a>{% endif %}
+					{% if v.admin_level >= 2 %}<a href="/votes?link={{c.fullname}}"><li class="list-group-item"><i class="fas fa-arrows-v mr-2"></i>Votes</li></a>{% endif %}
 
 					<a class="list-group-item" href="{{c.permalink}}"><i class="fas fa-book-open mr-2"></i>Context</a>
 

--- a/files/templates/post_actions.html
+++ b/files/templates/post_actions.html
@@ -6,7 +6,7 @@
 {% endif %}
 
 
-{# {% if not p.ghost or v.id == AEVANN_ID %}<a class="list-inline-item" href="/votes?link={{p.fullname}}"><i class="fas fa-arrows-v"></i>Votes</a>{% endif %} #}
+{# {% if v.admin_level >= 2 %}<a class="list-inline-item" href="/votes?link={{p.fullname}}"><i class="fas fa-arrows-v"></i>Votes</a>{% endif %} #}
 
 {# <a class="list-inline-item copy-link" role="button" data-clipboard-text="{{p.permalink}}"><i class="fas fa-copy"></i>Copy link</a> #}
 

--- a/files/templates/post_actions_mobile.html
+++ b/files/templates/post_actions_mobile.html
@@ -6,7 +6,7 @@
 {% endif %}
 
 
-{% if not p.ghost or v.id == AEVANN_ID %}<a class="btn-block" href="/votes?link={{p.fullname}}"><button class="nobackground btn btn-link btn-block btn-lg text-left text-muted"><i class="fas fa-arrows-v text-center text-muted mr-3"></i>Votes</button></a>{% endif %}
+{% if v.admin_level >= 2 %}<a class="btn-block" href="/votes?link={{p.fullname}}"><button class="nobackground btn btn-link btn-block btn-lg text-left text-muted"><i class="fas fa-arrows-v text-center text-muted mr-3"></i>Votes</button></a>{% endif %}
 
 <button data-bs-dismiss="modal" class="copy-link nobackground btn btn-link btn-block btn-lg text-left text-muted" data-clipboard-text="{{p.permalink}}"><i class="far fa-copy text-center text-muted mr-3"></i>Copy link</button>
 

--- a/files/templates/userpage.html
+++ b/files/templates/userpage.html
@@ -104,7 +104,9 @@
 				{% else %}<pre></pre>
 				{% endif %}
 				
-				<div class="font-weight-bolder mb-2"><a class="mr-1" href="/@{{u.username}}/upvoters">Upvoters</a> | <a class="mx-1" href="/@{{u.username}}/downvoters">Downvoters</a> | <a class="mx-1" href="/@{{u.username}}/upvoting">Upvoted</a> | <a class="ml-1" href="/@{{u.username}}/downvoting">Downvoted</a></div>
+				{% if u.admin_level >= 2 %}
+					<div class="font-weight-bolder mb-2"><a class="mr-1" href="/@{{u.username}}/upvoters">Upvoters</a> | <a class="mx-1" href="/@{{u.username}}/downvoters">Downvoters</a> | <a class="mx-1" href="/@{{u.username}}/upvoting">Upvoted</a> | <a class="ml-1" href="/@{{u.username}}/downvoting">Downvoted</a></div>
+				{% endif %}
 
 				<div class="font-weight-bolder">
 					<a href="/@{{u.username}}/followers">{{u.stored_subscriber_count}} follower{{'s' if u.stored_subscriber_count != 1 else ''}}</a>&nbsp;&nbsp;
@@ -363,7 +365,9 @@
 					<pre></pre>
 				{% endif %}
 
-				<div class="font-weight-bolder mb-2"><a class="mr-1" href="/@{{u.username}}/upvoters">Upvoters</a> | <a class="mx-1" href="/@{{u.username}}/downvoters">Downvoters</a> | <a class="mx-1" href="/@{{u.username}}/upvoting">Upvoted</a> | <a class="ml-1" href="/@{{u.username}}/downvoting">Downvoted</a></div>
+				{% if u.admin_level >= 2 %}
+					<div class="font-weight-bolder mb-2"><a class="mr-1" href="/@{{u.username}}/upvoters">Upvoters</a> | <a class="mx-1" href="/@{{u.username}}/downvoters">Downvoters</a> | <a class="mx-1" href="/@{{u.username}}/upvoting">Upvoted</a> | <a class="ml-1" href="/@{{u.username}}/downvoting">Downvoted</a></div>
+				{% endif %}
 
 				<div class="font-weight-normal">
 					<a href="/@{{u.username}}/followers" class="font-weight-bold">{{u.stored_subscriber_count}} follower{{'s' if u.stored_subscriber_count != 1 else ''}}</a>&nbsp;&nbsp;

--- a/files/templates/userpage.html
+++ b/files/templates/userpage.html
@@ -104,7 +104,7 @@
 				{% else %}<pre></pre>
 				{% endif %}
 				
-				{% if u.admin_level >= 2 %}
+				{% if v.admin_level >= 2 %}
 					<div class="font-weight-bolder mb-2"><a class="mr-1" href="/@{{u.username}}/upvoters">Upvoters</a> | <a class="mx-1" href="/@{{u.username}}/downvoters">Downvoters</a> | <a class="mx-1" href="/@{{u.username}}/upvoting">Upvoted</a> | <a class="ml-1" href="/@{{u.username}}/downvoting">Downvoted</a></div>
 				{% endif %}
 
@@ -365,7 +365,7 @@
 					<pre></pre>
 				{% endif %}
 
-				{% if u.admin_level >= 2 %}
+				{% if v.admin_level >= 2 %}
 					<div class="font-weight-bolder mb-2"><a class="mr-1" href="/@{{u.username}}/upvoters">Upvoters</a> | <a class="mx-1" href="/@{{u.username}}/downvoters">Downvoters</a> | <a class="mx-1" href="/@{{u.username}}/upvoting">Upvoted</a> | <a class="ml-1" href="/@{{u.username}}/downvoting">Downvoted</a></div>
 				{% endif %}
 


### PR DESCRIPTION
It is intentional that the links show up on admin level 2 but aren't usable until admin level 3; I don't know what I want right now and I want to encourage admins to pester me about it.