### PR TITLE
Fixes #110 "Signout doesn't always work"

### DIFF
--- a/files/routes/login.py
+++ b/files/routes/login.py
@@ -167,7 +167,7 @@ def me(v):
 	else: return redirect(v.url)
 
 
-@app.post("/logout")
+@app.get("/logout")
 @limiter.limit("1/second;30/minute;200/hour;1000/day")
 @auth_required
 def logout(v):
@@ -175,7 +175,7 @@ def logout(v):
 	session.pop("session_id", None)
 	session.pop("lo_user", None)
 
-	return {"message": "Logout successful!"}
+	return redirect('/')
 
 
 @app.get("/signup")

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -152,7 +152,7 @@
 								<a class="dropdown-item" href="/contact"><i class="fas fa-file-signature fa-fw mr-3"></i>Contact us</a>
 							</div>
 							<div class="px-2">
-								<a class="dropdown-item" role="button", onclick="post_toast(this,'/logout', '1')"><i class="fas fa-sign-out fa-fw mr-3"></i>Log out</a>
+								<a class="dropdown-item" role="button" href="/logout"><i class="fas fa-sign-out fa-fw mr-3"></i>Log out</a>
 							</div>
 						</div>
 					</div>
@@ -199,7 +199,7 @@
 				<a class="nav-item nav-link" href="/contact"><i class="fas fa-file-signature fa-fw mr-3"></i>Contact us</a>
 
 				<li class="nav-item border-top border-bottom mt-2 pt-2">
-					<a class="nav-link" role="button", onclick="post_toast(this,'/logout', '1')"><i class="fas fa-sign-out fa-fw mr-3 text-danger"></i>Log out</a>
+					<a class="nav-link" role="button" href="/logout"><i class="fas fa-sign-out fa-fw mr-3 text-danger"></i>Log out</a>
 				</li>
 			{% else %}
 				<li class="nav-item d-flex align-items-center justify-content-center pb-3">


### PR DESCRIPTION
I tried reproducing the issues from #110 but without luck. Can you @mjhouse remember the exact steps that would leave the avatar unchanged?

The workflow looks a little like this:

- User changes their avatar.
    - This triggers a POST request to the profile endpoint.
- User clicks "Log out" from the dropdown menu"
    - This triggers the post_toast function in js that makes a POST to
      /logout, which clears the user's session. Then, on receipt of the
      response, the js calls `location.reload`, which replays the
      browser's last action, which in our case is the earlier POST
      request to the profile endpoint. This is why the browser asks
      whether it's OK to resubmit the data _again_. Agreeing resubmits
      the first POST request.
    - After `location.reload`, since the user is no longer logged in,
      they either get a 405 (from the profile edit page) or a 500 (from
      the profile overview page).

Not sure where in this flow would the old avatar/username reassert itself.


That said, PR then changes the `/logout` endpoint from POST to GET, then
updates the header template to change the "Log out" anchor to simply
link to "/logout" instead of calling any js.

Reasoning behind it:
- logout doesn't modify server-side resources, so it's safe to make it a
  GET request.
- Making it a GET prevents the browser from ever displaying the "data
  resubmit" warning window.
- The "/logout" endpoint can now simply redirect to the homepage.

This fixes a bug when signing out from the profile page which returns a 500 error. This also fixes an error where signing out after updating the avatar displays a 405 error. 