### PR TITLE
141 - Comment preview is obviously a preview

### DIFF
--- a/files/assets/css/TheMotte.css
+++ b/files/assets/css/TheMotte.css
@@ -356,3 +356,13 @@ a.visited,
 .micromodal-slide.is-open {
 	display: block;
 }
+
+.comment-section div[id^="form-preview-"] {
+  border: 1px dashed black;
+  border-radius: 0.35em;
+  padding: 0.375rem 0.75rem;
+}
+
+.comment-section div[id^="form-preview-"] p.preview-msg {
+  color: gray;
+}

--- a/files/templates/authforms.html
+++ b/files/templates/authforms.html
@@ -16,14 +16,14 @@
 		{% if v %}
 			<style>:root{--primary:#{{v.themecolor}}}</style>
 			<link rel="stylesheet" href="/assets/css/main.css?v=250">
-			<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=56">
+			<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=57">
 			{% if v.css %}
 				<link rel="stylesheet" href="/@{{v.username}}/css">
 			{% endif %}
 		{% else %}
 			<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 			<link rel="stylesheet" href="/assets/css/main.css?v=250">
-			<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+			<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 		{% endif %}
 
 </head>

--- a/files/templates/chat.html
+++ b/files/templates/chat.html
@@ -15,7 +15,7 @@
 
 	<style>:root{--primary:#{{v.themecolor}}}</style>
 	<link rel="stylesheet" href="/assets/css/main.css?v=250">
-	<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=56">
+	<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=57">
 	{% if v.css %}
 		<link rel="stylesheet" href="/@{{v.username}}/css">
 	{% endif %}

--- a/files/templates/default.html
+++ b/files/templates/default.html
@@ -9,14 +9,14 @@
 	{% if v %}
 		<style>:root{--primary:#{{v.themecolor}}}</style>
 		<link rel="stylesheet" href="/assets/css/main.css?v=250">
-		<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=56">
+		<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=57">
 		{% if v.css %}
 			<link rel="stylesheet" href="/@{{v.username}}/css">
 		{% endif %}
 	{% else %}
 		<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 		<link rel="stylesheet" href="/assets/css/main.css?v=250">
-		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 	{% endif %}
 
 	{% if request.path == '/catalog' %}

--- a/files/templates/log.html
+++ b/files/templates/log.html
@@ -7,14 +7,14 @@
 {% if v %}
 	<style>:root{--primary:#{{v.themecolor}}}</style>
 	<link rel="stylesheet" href="/assets/css/main.css?v=250">
-	<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=56">
+	<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=57">
 	{% if v.css %}
 		<link rel="stylesheet" href="/@{{v.username}}/css">
 	{% endif %}
 {% else %}
 	<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 	<link rel="stylesheet" href="/assets/css/main.css?v=250">
-	<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+	<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 {% endif %}
 
 <div class="row justify-content-around">

--- a/files/templates/login.html
+++ b/files/templates/login.html
@@ -19,7 +19,7 @@
 	
 	<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 	<link rel="stylesheet" href="/assets/css/main.css?v=250">
-	<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+	<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 
 </head>
 

--- a/files/templates/login_2fa.html
+++ b/files/templates/login_2fa.html
@@ -15,7 +15,7 @@
 
 		<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 		<link rel="stylesheet" href="/assets/css/main.css?v=250">
-		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 
 </head>
 

--- a/files/templates/settings.html
+++ b/files/templates/settings.html
@@ -35,7 +35,7 @@
 
 	<style>:root{--primary:#{{v.themecolor}}}</style>
 	<link rel="stylesheet" href="/assets/css/main.css?v=250">
-	<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=56">
+	<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=57">
 	{% if v.css and not request.path.startswith('/settings/css') %}
 		<link rel="stylesheet" href="/@{{v.username}}/css">
 	{% endif %}

--- a/files/templates/settings2.html
+++ b/files/templates/settings2.html
@@ -40,11 +40,11 @@
 	{% if v %}
 		<style>:root{--primary:#{{v.themecolor}}}</style>
 		<link rel="stylesheet" href="/assets/css/main.css?v=250">
-		<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=56">
+		<link rel="stylesheet" href="/assets/css/{{v.theme}}.css?v=57">
 	{% else %}
 		<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 		<link rel="stylesheet" href="/assets/css/main.css?v=250">
-		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 	{% endif %}
 </head>
 

--- a/files/templates/sign_up.html
+++ b/files/templates/sign_up.html
@@ -32,7 +32,7 @@
 
 		<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 		<link rel="stylesheet" href="/assets/css/main.css?v=250">
-		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 
 </head>
 

--- a/files/templates/sign_up_failed_ref.html
+++ b/files/templates/sign_up_failed_ref.html
@@ -33,7 +33,7 @@
 
 		<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
 		<link rel="stylesheet" href="/assets/css/main.css?v=250">
-		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=56">
+		<link rel="stylesheet" href="/assets/css/{{config('DEFAULT_THEME')}}.css?v=57">
 
 </head>
 

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -495,7 +495,7 @@
 				</div>
 				<a id="save-reply-to-{{p.fullname}}" role="button" form="reply-to-{{p.fullname}}" class="btn btn-primary text-whitebtn ml-auto fl-r" onclick="post_comment('{{p.fullname}}', '{{p.id}}')">Comment</a>
 			</form>
-			<div id="form-preview-{{p.id}}" class="mb-3 mt-5"></div>
+			<div id="form-preview-{{p.id}}" class="text-small mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>
 			<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
 		</div>
 	{% else %}


### PR DESCRIPTION
This PR reworks the comment preview to include a border and initial
message identifying it as "Comment preview" (fixes #141). It also bumps all the
TheMotte.css versions from 56 to 57.

Empty comment box:
![motte1_commentpreview_empty](https://user-images.githubusercontent.com/109989267/182225897-85ff9452-8586-413c-a715-909d3efefdfb.png)

Comment box w/ content:
![motte1_commentpreview](https://user-images.githubusercontent.com/109989267/182226021-8e353c2b-a6ad-4685-b8e3-242743d605c1.png)

