### PR TITLE
115: Add cap on number of mentions

### DIFF
--- a/env
+++ b/env
@@ -33,3 +33,4 @@ DESCRIPTION=A place for people who want to test their ideas.
 CF_KEY=blahblahblah
 CF_ZONE=blahblahblah
 DEBIAN_FRONTEND=noninteractive
+MENTION_LIMIT=100

--- a/files/__main__.py
+++ b/files/__main__.py
@@ -60,6 +60,7 @@ app.config['MAIL_PASSWORD'] = environ.get("MAIL_PASSWORD", "").strip()
 app.config['DESCRIPTION'] = environ.get("DESCRIPTION", "DESCRIPTION GOES HERE").strip()
 app.config['SETTINGS'] = {}
 app.config['SQLALCHEMY_DATABASE_URI'] = app.config['DATABASE_URL']
+app.config['MENTION_LIMIT'] = int(environ.get('MENTION_LIMIT', 100))
 
 r=redis.Redis(host=environ.get("REDIS_URL", "redis://localhost"), decode_responses=True, ssl_cert_reqs=None)
 

--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -11,6 +11,7 @@ from random import random, choice
 import signal
 import time
 import requests
+from files.__main__ import app
 
 TLDS = ('ac','ad','ae','aero','af','ag','ai','al','am','an','ao','aq','ar','arpa','as','asia','at','au','aw','ax','az','ba','bb','bd','be','bf','bg','bh','bi','biz','bj','bm','bn','bo','br','bs','bt','bv','bw','by','bz','ca','cafe','cat','cc','cd','cf','cg','ch','ci','ck','cl','club','cm','cn','co','com','coop','cr','cu','cv','cx','cy','cz','de','dj','dk','dm','do','dz','ec','edu','ee','eg','er','es','et','eu','fi','fj','fk','fm','fo','fr','ga','gb','gd','ge','gf','gg','gh','gi','gl','gm','gn','gov','gp','gq','gr','gs','gt','gu','gw','gy','hk','hm','hn','hr','ht','hu','id','ie','il','im','in','info','int','io','iq','ir','is','it','je','jm','jo','jobs','jp','ke','kg','kh','ki','km','kn','kp','kr','kw','ky','kz','la','lb','lc','li','lk','lr','ls','lt','lu','lv','ly','ma','mc','md','me','mg','mh','mil','mk','ml','mm','mn','mo','mobi','mp','mq','mr','ms','mt','mu','museum','mv','mw','mx','my','mz','na','name','nc','ne','net','nf','ng','ni','nl','no','np','nr','nu','nz','om','org','pa','pe','pf','pg','ph','pk','pl','pm','pn','post','pr','pro','ps','pt','pw','py','qa','re','ro','rs','ru','rw','sa','sb','sc','sd','se','sg','sh','si','sj','sk','sl','sm','sn','so','social','sr','ss','st','su','sv','sx','sy','sz','tc','td','tel','tf','tg','th','tj','tk','tl','tm','tn','to','tp','tr','travel','tt','tv','tw','tz','ua','ug','uk','us','uy','uz','va','vc','ve','vg','vi','vn','vu','wf','win','ws','xn','xxx','xyz','ye','yt','yu','za','zm','zw')
 
@@ -161,6 +162,13 @@ def sanitize(sanitized, alert=False, comment=False, edit=False):
 		matches = [ m for m in mention_regex.finditer(sanitized) if m ]
 		names = set( m.group(2) for m in matches )
 		users = get_users(names,graceful=True)
+
+		if len(users) > app.config['MENTION_LIMIT']:
+			signal.alarm(0)
+			abort(
+				make_response(
+					jsonify(
+						error=f'Mentioned {len(users)} users but limit is {app.config["MENTION_LIMIT"]}'), 400))
 
 		for u in users:
 			if not u: continue


### PR DESCRIPTION
Closes #115 

This caps the number of mentions in a submission or comment to
MENTION_LIMIT, which is set to 100 by default. When limit is exceeded,
returns a helpful message to the user.

User UI:

![mention_cap](https://user-images.githubusercontent.com/109989267/182474633-ec969bd2-7a3c-4a91-a57b-a91028a283b8.png)
