### PR TITLE
139: Disabled multimedia embedding

### DIFF
--- a/env
+++ b/env
@@ -33,3 +33,4 @@ DESCRIPTION=A place for people who want to test their ideas.
 CF_KEY=blahblahblah
 CF_ZONE=blahblahblah
 DEBIAN_FRONTEND=noninteractive
+MULTIMEDIA_EMBEDDING_ENABLED=False

--- a/files/__main__.py
+++ b/files/__main__.py
@@ -60,6 +60,7 @@ app.config['MAIL_PASSWORD'] = environ.get("MAIL_PASSWORD", "").strip()
 app.config['DESCRIPTION'] = environ.get("DESCRIPTION", "DESCRIPTION GOES HERE").strip()
 app.config['SETTINGS'] = {}
 app.config['SQLALCHEMY_DATABASE_URI'] = app.config['DATABASE_URL']
+app.config['MULTIMEDIA_EMBEDDING_ENABLED'] = environ.get('MULTIMEDIA_EMBEDDING_ENABLED', "false").lower() == "true"
 
 r=redis.Redis(host=environ.get("REDIS_URL", "redis://localhost"), decode_responses=True, ssl_cert_reqs=None)
 

--- a/files/assets/js/gif_modal.js
+++ b/files/assets/js/gif_modal.js
@@ -43,7 +43,7 @@ async function getGif(searchTerm) {
 
 		let response = await fetch("/giphy?searchTerm=" + searchTerm + "&limit=48");
 		let data = await response.json()
-		var max = data.length - 1
+		var max = data.data?.length === undefined ? 0 : data.data.length - 1
 		data = data.data
 					var gifURL = [];
 
@@ -70,7 +70,10 @@ async function getGif(searchTerm) {
 
 function insertGIF(url,form) {
 
-	var gif = "\n\n![](" + url +")";
+	// https://github.com/themotte/rDrama/issues/139
+	// when MULTIMEDIA_EMBEDDING_ENABLED == False, we want to insert an anchor, NOT an img
+	//var gif = "\n\n![](" + url +")";
+	var gif = '\n\n[' + url + '](' + url + ')';
 
 	var commentBox = document.getElementById(form);
 

--- a/files/assets/js/marked.custom.js
+++ b/files/assets/js/marked.custom.js
@@ -65,7 +65,9 @@ function markdown(first, second) {
 			dest.removeChild(dest.children[i]);
 		}
 		const html = marked.parse(input.value);
-		dest.innerHTML = DOMPurify.sanitize(html);
+		// https://github.com/themotte/rDrama/issues/139
+		// Remove disallowed tags completely.
+		dest.innerHTML = DOMPurify.sanitize(html, {FORBID_TAGS: ['img', 'video', 'source']});
 	}
 }
 

--- a/files/routes/comments.py
+++ b/files/routes/comments.py
@@ -232,7 +232,10 @@ def api_comment(v):
 							requests.post(f'https://api.cloudflare.com/client/v4/zones/{CF_ZONE}/purge_cache', headers=CF_HEADERS, data={'files': [f"https://{request.host}/assets/images/badges/{badge.id}.webp"]}, timeout=5)
 						except Exception as e:
 							return {"error": str(e)}, 400
-				body += f"\n\n![]({image})"
+				if app.config['MULTIMEDIA_EMBEDDING_ENABLED']:
+					body += f"\n\n![]({image})"
+				else:
+					body += f'\n\n<a href="{image}">{image}</a>'
 			elif file.content_type.startswith('video/'):
 				file.save("video.mp4")
 				with open("video.mp4", 'rb') as f:
@@ -244,7 +247,10 @@ def api_comment(v):
 						if error == 'File exceeds max duration': error += ' (60 seconds)'
 						return {"error": error}, 400
 				if url.endswith('.'): url += 'mp4'
-				body += f"\n\n{url}"
+				if app.config['MULTIMEDIA_EMBEDDING_ENABLED']:
+					body += f"\n\n{url}"
+				else:
+					body += f'\n\n<a href="{url}">{url}</a>'
 			else: return {"error": "Image/Video files only"}, 400
 
 	body_html = sanitize(body, comment=True)

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -457,7 +457,10 @@ def edit_post(pid, v):
 				name = f'/images/{time.time()}'.replace('.','') + '.webp'
 				file.save(name)
 				url = process_image(name)
-				body += f"\n\n![]({url})"
+				if app.config['MULTIMEDIA_EMBEDDING_ENABLED']:
+					body += f"\n\n![]({url})"
+				else:
+					body += f'\n\n<a href="{url}">{url}</a>'
 			elif file.content_type.startswith('video/'):
 				file.save("video.mp4")
 				with open("video.mp4", 'rb') as f:
@@ -469,7 +472,10 @@ def edit_post(pid, v):
 						if error == 'File exceeds max duration': error += ' (60 seconds)'
 						return {"error": error}, 400
 				if url.endswith('.'): url += 'mp4'
-				body += f"\n\n{url}"
+				if app.config['MULTIMEDIA_EMBEDDING_ENABLED']:
+					body += f"\n\n![]({url})"
+				else:
+					body += f'\n\n<a href="{url}">{url}</a>'
 			else: return {"error": "Image/Video files only"}, 400
 
 	body_html = sanitize(body, edit=True)
@@ -902,7 +908,11 @@ def submit_post(v, sub=None):
 			if file.content_type.startswith('image/'):
 				name = f'/images/{time.time()}'.replace('.','') + '.webp'
 				file.save(name)
-				body += f"\n\n![]({process_image(name)})"
+				image = process_image(name)
+				if app.config['MULTIMEDIA_EMBEDDING_ENABLED']:
+					body += f"\n\n![]({image})"
+				else:
+					body += f'\n\n<a href="{image}">{image}</a>'
 			elif file.content_type.startswith('video/'):
 				file.save("video.mp4")
 				with open("video.mp4", 'rb') as f:
@@ -914,7 +924,10 @@ def submit_post(v, sub=None):
 						if err == 'File exceeds max duration': err += ' (60 seconds)'
 						return error(err)
 				if url.endswith('.'): url += 'mp4'
-				body += f"\n\n{url}"
+				if app.config['MULTIMEDIA_EMBEDDING_ENABLED']:
+					body += f"\n\n![]({url})"
+				else:
+					body += f'\n\n<a href="{url}">{url}</a>'
 			else:
 				return error("Image/Video files only.")
 

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -841,7 +841,7 @@
 	{% if v %}
 		<script src="/assets/js/vendor/purify.min.js?v=251"></script>
 		<script src="/assets/js/vendor/marked.min.js?v=251"></script>
-		<script src="/assets/js/marked.custom.js?v=251"></script>
+		<script src="/assets/js/marked.custom.js?v=252"></script>
 		<script src="/assets/js/comments_v.js?v=266"></script>
 		<script src="/assets/js/award_modal.js?v=1"></script>
 	{% endif %}

--- a/files/templates/formatting.html
+++ b/files/templates/formatting.html
@@ -69,17 +69,17 @@ Text 2
 		<tr>
 			<td>Images</td>
 			<td>https://i.imgur.com/SwVuagI_d.webp</td>
-			<td><img loading="lazy" alt="example image" referrerpolicy="no-referrer" src="https://i.imgur.com/SwVuagI_d.webp"></td>
+			<td><a href="https://i.imgur.com/SwVuagI_d.webp">https://i.imgur.com/SwVuagI_d.webp</td>
 		</tr>
 		<tr>
 			<td>Youtube Videos</td>
 			<td>https://youtube.com/watch?v=3Hecr51ByE4</td>
-			<td><lite-youtube videoid="3Hecr51ByE4" params="autoplay=1&modestbranding=1"></lite-youtube></td>
+			<td><a href="https://youtube.com/watch?v=3Hecr51ByE4">https://youtube.com/watch?v=3Hecr51ByE4</a></td>
 		</tr>
 		<tr>
 			<td>Video Files</td>
 			<td>https://files.catbox.moe/v4om92.mp4</td>
-			<td><video controls preload="none" class="vid"><source referrerpolicy="no-referrer" src="https://files.catbox.moe/v4om92.mp4" type="video/mp4"></video></td>
+			<td><a href="https://files.catbox.moe/v4om92.mp4">https://files.catbox.moe/v4om92.mp4</a></td>
 		</tr>
 		<tr>
 			<td>Poll Options (can select multiple options)</td>
@@ -458,7 +458,7 @@ line breaks
 				&lt;img referrerpolicy="no-referrer" src="https://i.imgur.com/SwVuagI_d.webp" width="200"&gt;
 			</td>
 			<td>
-				<img loading="lazy" alt="example image" referrerpolicy="no-referrer" src="https://i.imgur.com/SwVuagI_d.webp" width="200">
+				Nothing!
 			</td>
 		</tr>
 	</tbody>

--- a/files/templates/gif_modal.html
+++ b/files/templates/gif_modal.html
@@ -26,4 +26,4 @@
 	</div>
 </div>
 
-<script src="/assets/js/gif_modal.js?v=244"></script>
+<script src="/assets/js/gif_modal.js?v=245"></script>

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -171,7 +171,7 @@
 
 		<script src="/assets/js/vendor/purify.min.js?v=251"></script>
 		<script src="/assets/js/vendor/marked.min.js?v=251"></script>
-		<script src="/assets/js/marked.custom.js?v=251"></script>
+		<script src="/assets/js/marked.custom.js?v=252"></script>
 		<script src="/assets/js/formatting.js?v=240"></script>
 		<script src="/assets/js/submit.js?v=255"></script>
 

--- a/files/templates/userpage.html
+++ b/files/templates/userpage.html
@@ -698,7 +698,7 @@
 {% endif %}
 
 <script src="/assets/js/vendor/purify.min.js?v=251"></script>
-<script src="/assets/js/vendor/marked.min.js?v=251"></script>
+<script src="/assets/js/vendor/marked.min.js?v=252"></script>
 <script src="/assets/js/marked.custom.js?v=251"></script>
 
 {% endblock %}


### PR DESCRIPTION
Fixes #139

This change disables multimedia embedding:

- In comments and comments replies.
- In new submissions.
- In comment & submission preview

And it's all toggle-able via an envvar, except for the JS bits,
but I linked those to the github issue, so should be easy to find
in the future.

The way it works is:

- removes markdown image/video syntax,
  eg. `![](https://example.org/someimage.jpg)` into ``
- changes link text into anchors, eg.
  `https://example.org/someimage.jpg` into
  `[https://example.org/someimage.jpg](https://example.org/someimage.jpg)`
- removes html img/video/audio tags, eg.
  `<img href="https://example.org/someimage.jpg" />` into ``
- when embedding gifs via the giphy modal in "new submission", it will
  insert only an anchor to the gif
- when attaching an image, it will upload the image, then add only an
  anchor to the post/comment body

I tested this manually, but not sure if I got all the test cases. What I
checked was:

- create comment w/ image/video/audio media using markdown -> success
- create comment reply w/ image/video/audio media using markdown ->
  success
- create comment w/ link to img/imgur/youtube/audio -> success
- create comment w/ attachment -> success
- create comment reply w/ attachment -> success
- create comment w/ img/video tag -> success
- create comment reply w/ image/video tag -> success
- create post submission w/ image/video/media using markdown -> success
- create post submission w/ link to img/imgur/youtube/audio -> success
- create post submission w/ attachment -> success
- create post submission w/ giphy gif -> success

Also, updated the formatting page.

Example of comment editing page w/ preview (submitted output looks the same, ie. sanitize.py produces the same output):

![input_sanitized](https://user-images.githubusercontent.com/109989267/182964546-24d6b48e-54bb-4c8f-8738-94894899db7d.png)
