### PR TITLE
143: Fix ordered list rendering

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -5154,3 +5154,12 @@ th, td {
 .mobile-comment-link {
 	color: var(--dark);
 }
+
+/* Fix for <ol> being populated with <li><p></p></li> in many contexts. */
+.post-body li > p:first-child,
+.comment-text li > p:first-child,
+.preview li > p:first-child,
+div[id^="form-preview-"] li > p:first-child,
+div[id^="reply-edit-"] li > p:first-child {
+	display: inline;
+}


### PR DESCRIPTION
Happy Friday :tada: 

Fixes #143 

The `linefeeds_regex` doubles every newline character. However, when
that happens, it turns tight numbered lists into loose numbered lists.

Context: https://stackoverflow.com/a/43505265

This commit changes the `linefeeds_regex` to NOT double newlines between lines that begin with a number.

![ordered_lists_correct](https://user-images.githubusercontent.com/109989267/184349239-1f04350c-32c7-4668-8903-37892ec5804f.png)



