### PR TITLE
Fix 2FA modal not displaying in UI (#178).

### DIFF
--- a/files/assets/js/settings_security.js
+++ b/files/assets/js/settings_security.js
@@ -3,7 +3,11 @@ document.getElementById('new_email').addEventListener('input', function () {
 	document.getElementById("email-password-label").classList.remove("d-none");
 	document.getElementById("emailpasswordRequired").classList.remove("d-none");
 });
-const twoStepModal = new bootstrap.Modal(document.getElementById('2faModal'))
+
+document.getElementById('2faToggle').addEventListener('change', function () {
+	const twoStepModal = new bootstrap.Modal(document.getElementById('2faModal'));
+	twoStepModal.show();
+});
 
 function emailVerifyText() {
 	document.getElementById("email-verify-text").innerHTML = "Verification email sent! Please check your inbox.";

--- a/files/templates/settings_security.html
+++ b/files/templates/settings_security.html
@@ -4,8 +4,6 @@
 
 {% block content %}
 
-<script src="/assets/js/settings_security.js?v=240"></script>
-
 <div class="row">
 
 <div class="col col-lg-8">
@@ -149,7 +147,7 @@
 	<div class="body w-lg-100">
 
 		<div class="custom-control custom-switch">
-		<input autocomplete="off" type="checkbox" class="custom-control-input" id="2faToggle" name="2faToggle" onchange="twoStepModal.show()" {% if v.mfa_secret %}checked{% endif %}>
+		<input autocomplete="off" type="checkbox" class="custom-control-input" id="2faToggle" name="2faToggle" {% if v.mfa_secret %}checked{% endif %}>
 		<label class="custom-control-label" for="2faToggle"></label>
 		</div>
 
@@ -258,5 +256,7 @@
 	</form>
 </div>
 </div>
+
+<script src="/assets/js/settings_security.js?v=241"></script>
 
 {% endblock %}


### PR DESCRIPTION
Fixes issue #178. Root cause was attempting to document.getElementById
of both modal and toggle input before both were loaded into the DOM.
In the upstream, Cloudflare's Rocket Loader is used, which papers over
many cases of inattention to loading order.