### PR TITLE
Fix improper calls to Comment.replies. (fixes #170 and #172)

### DIFF
--- a/files/classes/comment.py
+++ b/files/classes/comment.py
@@ -344,8 +344,7 @@ class Comment(Base):
 
 			if self.level>=2: data['parent_comment_id']= self.parent_comment_id
 
-		if "replies" in self.__dict__:
-			data['replies']=[x.json_core for x in self.replies]
+		data['replies']=[x.json_core for x in self.replies(None)]
 
 		return data
 

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -418,7 +418,7 @@ def morecomments(v, cid):
 		comments = output
 	else:
 		c = g.db.query(Comment).filter_by(id=cid).one_or_none()
-		comments = c.replies
+		comments = c.replies(None)
 
 	if comments: p = comments[0].post
 	else: p = None

--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -687,7 +687,7 @@ def messagereply(v):
 		if not notif:
 			notif = Notification(comment_id=c.id, user_id=user_id)
 			g.db.add(notif)
-			ids = [c.top_comment.id] + [x.id for x in c.top_comment.replies]
+			ids = [c.top_comment.id] + [x.id for x in c.top_comment.replies_ignoring_shadowbans]
 			notifications = g.db.query(Notification).filter(Notification.comment_id.in_(ids), Notification.user_id == user_id)
 			for n in notifications:
 				g.db.delete(n)
@@ -726,7 +726,7 @@ def messagereply(v):
 			notif = Notification(comment_id=c.id, user_id=admin.id)
 			g.db.add(notif)
 
-		ids = [c.top_comment.id] + [x.id for x in c.top_comment.replies]
+		ids = [c.top_comment.id] + [x.id for x in c.top_comment.replies_ignoring_shadowbans]
 		notifications = g.db.query(Notification).filter(Notification.comment_id.in_(ids))
 		for n in notifications:
 			g.db.delete(n)


### PR DESCRIPTION
In four contexts, Comment.replies(.) was not updated to reflect the interface changes with comment filtering. This directly caused #170 and #172 (which was a stack trace from the former).
  - Updating notifications for DMs (routes/users.py L690)
  - Updating notifications for modmail (routes/users.py L729)
  - morecomments for logged out users (routes/posts.py L421)
  - JSON for API access (classes/comment.py L347)

All four contexts seem to behave correctly after the change. However, strictly speaking the JSON generation will not include a user's own filtered or removed comments, though this is hard to remedy without passing the user object `v` to json_core. Propagating that through the codebase seems a worse option than leaving it as is.