### PR TITLE
Fix desktop header dropdown menu clipping off page.

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -4448,7 +4448,7 @@ textarea {
 }
 @media (min-width: 767.98px) {
 	.navbar {
-		padding: 0.5rem 3rem 0.4rem 0.5rem;
+		padding: 0.5rem 1.5rem 0.4rem 0.5rem;
 }
 }
 blockquote {
@@ -5056,6 +5056,10 @@ th, td {
 	.settings-nav .nav-link {
 		font-size: 12px;
 	}
+}
+
+#account-menu-header, #account-menu {
+	min-width: 10em;
 }
 
 .glow .post-title, .glow a, .glow .post-meta *, .glow .user-info *, .glow .comment-text, .glow .comment-actions *, .glow  {

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -125,7 +125,7 @@
 				</li>
 
 				<li class="nav-item d-flex align-items-center justify-content-center text-center">
-					<div class="dropdown">
+					<div class="dropdown" id="account-menu-header">
 						<a class="nav-link bg-transparent py-0 pr-0" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown"
 						aria-haspopup="true" aria-expanded="false">
 						<div class="d-flex">


### PR DESCRIPTION
The width of the account menu dropdown header is determined by the length of one's username. Users with short names cause the dropdown menu to partially clip off the right side of the page, which is unsightly and impedes usage thereof. This commit enforces a minimum width to prevent that.

Alternate approaches such as right-aligning the dropdown proved unwieldy with CSS when fixing this same bug on the upstream.

---

This PR doesn't cachebust main.css, so perhaps merge before https://github.com/themotte/rDrama/pull/183

![](https://i.imgur.com/OGp6CET.png)