### PR TITLE
Only show /leaderboard link in settings2 menu to admins.

### DIFF
--- a/files/routes/errors.py
+++ b/files/routes/errors.py
@@ -31,7 +31,7 @@ def error_403(e):
 		if not description: description = "403 Forbidden"
 		return {"error": description}, 403
 	else:
-		if not description: description = "YOU AREN'T WELCOME HERE GO AWAY"
+		if not description: description = "You don't have access to this page."
 		return render_template('errors/403.html', description=description, err=True), 403
 
 

--- a/files/templates/settings2.html
+++ b/files/templates/settings2.html
@@ -63,23 +63,37 @@
 						<div class="col">
 							<div class="d-flex flex-row-reverse justify-content-end">
 								<ul class="nav settings-nav" style="margin-left: -15px;">
+									{% if v and v.admin_level >= 2 %}
+										<li class="nav-item">
+											<a class="nav-link{% if request.path.endswith('/leaderboard') %} active{% endif %}" href="/leaderboard">
+												<i class="fas fa-trophy pr-2"></i>Leaderboard
+											</a>
+										</li>
+									{% endif %}
 									<li class="nav-item">
-										<a class="nav-link{% if request.path.endswith('/leaderboard') %} active{% endif %}" href="/leaderboard"><i class="fas fa-trophy pr-2"></i>Leaderboard</a>
+										<a class="nav-link{% if request.path.endswith('/admins') %} active{% endif %}" href="/admins">
+											<i class="fas fa-crown pr-2"></i>Admins
+										</a>
 									</li>
 									<li class="nav-item">
-										<a class="nav-link{% if request.path.endswith('/admins') %} active{% endif %}" href="/admins"><i class="fas fa-crown pr-2"></i>Admins</a>
+										<a class="nav-link{% if request.path.endswith('/log') %} active{% endif %}" href="/log">
+											<i class="fas fa-scroll-old pr-2"></i>Moderation Log
+										</a>
 									</li>
 									<li class="nav-item">
-										<a class="nav-link{% if request.path.endswith('/log') %} active{% endif %}" href="/log"><i class="fas fa-scroll-old pr-2"></i>Moderation Log</a>
+										<a class="nav-link{% if request.path.endswith('/banned') %} active{% endif %}" href="/banned">
+											<i class="fas fa-user-slash pr-2"></i>Permabanned Users
+										</a>
 									</li>
 									<li class="nav-item">
-										<a class="nav-link{% if request.path.endswith('/banned') %} active{% endif %}" href="/banned"><i class="fas fa-user-slash pr-2"></i>Permabanned Users</a>
+										<a class="nav-link{% if request.path.endswith('/blocks') %} active{% endif %}" href="/blocks">
+											<i class="fas fa-user-slash pr-2"></i>Blocks
+										</a>
 									</li>
 									<li class="nav-item">
-										<a class="nav-link{% if request.path.endswith('/blocks') %} active{% endif %}" href="/blocks"><i class="fas fa-user-slash pr-2"></i>Blocks</a>
-									</li>
-									<li class="nav-item">
-										<a class="nav-link{% if request.path.endswith('/changelog') %} active{% endif %}" href="/changelog"><i class="fas fa-clipboard pr-2"></i>Changelog</a>
+										<a class="nav-link{% if request.path.endswith('/changelog') %} active{% endif %}" href="/changelog">
+											<i class="fas fa-clipboard pr-2"></i>Changelog
+										</a>
 									</li>
 								</ul>
 							</div>


### PR DESCRIPTION
Also a more polite 403 message, also more readable HTML.

 Addresses #203. Can confirm that /leaderboard is only accessible to users with admin_level >= 2.