### PR TITLE
Fix an error with trying to sanitize really ugly HTML

### DIFF
--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -71,7 +71,9 @@ def allowed_attributes(tag, name, value):
 url_re = build_url_re(tlds=TLDS, protocols=['http', 'https'])
 
 def callback(attrs, new=False):
-	href = attrs[(None, "href")]
+	href = attrs.get((None, "href"), None)
+	if href == None:
+		return attrs
 
 	if not href.startswith('/') and not href.startswith(f'{SITE_FULL}/'):
 		attrs[(None, "target")] = "_blank"


### PR DESCRIPTION
This change fixes the 500 error that happens with the HTML fuzzer code in issue #160.

With this fix, the post create actually works and none of the tricks seem to make it into the HTML. The preview is still pretty weird, and the resulting post has pretty odd formatting. We may want to do more with this issue, but at least with this, the post creates and none of the XSS attempts work.