### PR TITLE
Fix tooltips (esp. for timestamps) not appearing, improve legibility thereof.

### DIFF
--- a/files/assets/css/TheMotte.css
+++ b/files/assets/css/TheMotte.css
@@ -372,3 +372,15 @@ a.visited,
 .comment-section div[id^="form-preview-"] p.preview-msg, div[id^="reply-edit-"] p.preview-msg {
   color: gray;
 }
+
+.tooltip {
+	color: var(--dark);
+	background-color: var(--light);
+	border: 1px solid var(--primary-light1);
+	border-radius: 0.5rem;
+}
+
+.tooltip-inner {
+	color: var(--dark);
+	background-color: var(--light);
+}

--- a/files/assets/js/header.js
+++ b/files/assets/js/header.js
@@ -63,8 +63,16 @@ function bs_trigger(e) {
 	})
 }
 
-bs_trigger(document)
+var bsTriggerOnReady = function() {
+	bs_trigger(document);
+}
 
+if (document.readyState === "complete" || 
+		(document.readyState !== "loading" && !document.documentElement.doScroll)) {
+	bsTriggerOnReady();
+} else {
+	document.addEventListener("DOMContentLoaded", bsTriggerOnReady);
+}
 
 function expandDesktopImage(image) {
 	document.getElementById("desktop-expanded-image").src = image.replace("200w_d.webp", "giphy.webp");

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -222,7 +222,7 @@
 	</div>
 </nav>
 
-<script src="/assets/js/header.js?v=266"></script>
+<script src="/assets/js/header.js?v=267"></script>
 
 {% if v and not err %}
 	<div id="formkey" class="d-none">{{v.formkey}}</div>


### PR DESCRIPTION
All of the code to have detailed timestamps appear when mouseovering the vague time-ago (ex: "7d ago") on posts/comments was present; however, due to JS loading order issues, it was not active. This is fixed by waiting to initialize tooltips until document is ready. Cachebusted header.js too.

After fixing this, it was discovered that TheMotte.css makes tooltips hard to read due to the (admittedly saner) way it defines color variables. I think I used the right colors to match the rest of the UI. Looks like:

![Screenshot](https://user-images.githubusercontent.com/104547575/187020943-9a5f0586-e2ca-4014-bc64-1d814b82f27d.png)