### PR TITLE
Fix flask-limiter having null limit_key (#222).

### DIFF
--- a/files/__main__.py
+++ b/files/__main__.py
@@ -6,6 +6,7 @@ import secrets
 from flask import *
 from flask_caching import Cache
 from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_compress import Compress
 from flask_mail import Mail
 from sqlalchemy.ext.declarative import declarative_base
@@ -64,13 +65,9 @@ app.config['MULTIMEDIA_EMBEDDING_ENABLED'] = environ.get('MULTIMEDIA_EMBEDDING_E
 
 r=redis.Redis(host=environ.get("REDIS_URL", "redis://localhost"), decode_responses=True, ssl_cert_reqs=None)
 
-def get_CF():
-	with app.app_context():
-		return request.headers.get('CF-Connecting-IP')
-
 limiter = Limiter(
 	app,
-	key_func=get_CF,
+	key_func=get_remote_address,
 	default_limits=["3/second;30/minute;200/hour;1000/day"],
 	application_limits=["10/second;200/minute;5000/hour;10000/day"],
 	storage_uri=environ.get("REDIS_URL", "redis://localhost")

--- a/files/routes/static.py
+++ b/files/routes/static.py
@@ -225,9 +225,6 @@ def log(v):
 
 	kind = request.values.get("kind")
 
-	if kind not in ACTIONTYPES:
-		logging.warning(f'Unfamiliar ACTIONTYPE {kind}')
-
 	if v and v.admin_level > 1:
 		types = ACTIONTYPES
 	else:


### PR DESCRIPTION
Fixes #222.

Recently, unrelated changes led to enabling logging for flask-limiter accidentally, at which point it was discovered that it wasn't actually limiting requests due to Limiter.key_func = get_CF not being proper for either prod (not behind Cloudflare) or localhost (likewise).

We instead use the remote_addr attached directly to the request using the existing flask-limiter function to do so.

Also, removes the check for invalid modaction kind in the `/log` route because it was logging not on backend error, but rather on invalid request data.

Detailed troubleshooting at: https://github.com/themotte/rDrama/issues/222#issuecomment-1229489062