### PR TITLE
Clarify permabanned forbidden messages. (Fixes #221)

### DIFF
--- a/files/classes/user.py
+++ b/files/classes/user.py
@@ -617,6 +617,9 @@ class User(Base):
 	def is_suspended(self):
 		return (self.is_banned and (self.unban_utc == 0 or self.unban_utc > time.time()))
 
+	@property
+	def is_suspended_permanently(self):
+		return (self.is_banned and self.unban_utc == 0)
 
 	@property
 	@lazy

--- a/files/helpers/wrappers.py
+++ b/files/helpers/wrappers.py
@@ -91,8 +91,8 @@ def is_not_permabanned(f):
 		
 		check_ban_evade(v)
 
-		if v.is_banned and v.unban_utc == 0:
-			return {"error": "Interal server error"}, 500
+		if v.is_suspended_permanently:
+			return {"error": "Forbidden: you are permabanned."}, 403
 
 		g.v = v
 		return make_response(f(*args, v=v, **kwargs))

--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -562,8 +562,11 @@ def reportbugs(v):
 
 @app.post("/@<username>/message")
 @limiter.limit("1/second;10/minute;20/hour;50/day")
-@is_not_permabanned
+@auth_required
 def message2(v, username):
+	if v.is_suspended_permanently:
+		return {"error": "You have been permabanned and cannot send messages; " + \
+			"contact modmail if you think this decision was incorrect."}, 403
 
 	user = get_user(username, v=v)
 	if hasattr(user, 'is_blocking') and user.is_blocking: return {"error": "You're blocking this user."}, 403


### PR DESCRIPTION
Fixes #221. Provides custom message behavior for the user DM route and slightly refactors the `@is_not_permabanned` wrapper to not be deliberately misleading to users.

In the interest of making a minimally invasive change, there is no link to modmail included in the toast message: we populate toasts using the `innerText` attribute, not `innerHTML`, so markup provided renders literally. I'm hesitant to change over to innerHTML since I don't believe we're terribly careful about sanitizing error messages, and there might be stored XSS risks—or might not be, but I'm not sure offhand.