### PR TITLE
Fix Limiter not using proper remote address as key.

### DIFF
--- a/files/__main__.py
+++ b/files/__main__.py
@@ -6,7 +6,6 @@ import secrets
 from flask import *
 from flask_caching import Cache
 from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
 from flask_compress import Compress
 from flask_mail import Mail
 from sqlalchemy.ext.declarative import declarative_base
@@ -65,9 +64,13 @@ app.config['MULTIMEDIA_EMBEDDING_ENABLED'] = environ.get('MULTIMEDIA_EMBEDDING_E
 
 r=redis.Redis(host=environ.get("REDIS_URL", "redis://localhost"), decode_responses=True, ssl_cert_reqs=None)
 
+def get_remote_addr():
+	with app.app_context():
+		return request.headers.get('X-Real-IP', default='127.0.0.1')
+
 limiter = Limiter(
 	app,
-	key_func=get_remote_address,
+	key_func=get_remote_addr,
 	default_limits=["3/second;30/minute;200/hour;1000/day"],
 	application_limits=["10/second;200/minute;5000/hour;10000/day"],
 	storage_uri=environ.get("REDIS_URL", "redis://localhost")


### PR DESCRIPTION
Previously discussed while debugging 429s in prod. K8s nginx-ingress reverse proxy was causing some strangeness with how `Request.remote_addr` is populated. Instead, we use the `X-Real-IP` header—which is apparently `X-Real-Ip` in prod, but Headers.get() is case insensitive:
https://github.com/pallets/werkzeug/blob/d05ee59d18b895bf204431a501bf6621f3077d5c/src/werkzeug/datastructures.py#L953-L964