### PR TITLE
Fix #230: present pinned posts first in all sorts.

### DIFF
--- a/files/routes/front.py
+++ b/files/routes/front.py
@@ -323,7 +323,7 @@ def frontlist(v=None, sort="hot", page=1, t="all", ids_only=True, ccmode="false"
 
 	posts = posts.filter_by(is_banned=False, private=False, deleted_utc = 0)
 
-	if (sort == "hot" or (v and v.id == Q_ID)) and ccmode == "false" and not gt and not lt:
+	if ccmode == "false" and not gt and not lt:
 		posts = posts.filter_by(stickied=None)
 
 	if v and v.admin_level < 2:
@@ -369,7 +369,7 @@ def frontlist(v=None, sort="hot", page=1, t="all", ids_only=True, ccmode="false"
 
 	posts = posts[:size]
 
-	if (sort == "hot" or (v and v.id == Q_ID)) and page == 1 and ccmode == "false" and not gt and not lt:
+	if page == 1 and ccmode == "false" and not gt and not lt:
 		pins = g.db.query(Submission).filter(Submission.stickied != None, Submission.is_banned == False)
 		if sub: pins = pins.filter_by(sub=sub.name)
 		elif v:


### PR DESCRIPTION
Fixes #230. We have existing logic for the Hot sort to always place pins first: essentially, build separate lists for both pins and non-pinned posts, and then concatenate the two. This commit simply removes the check which only does this on Hot.