### PR TITLE
Assorted fixes & porting from upstream.

### DIFF
--- a/files/assets/css/classic.css
+++ b/files/assets/css/classic.css
@@ -66,9 +66,9 @@ body, .card, #main-content-row {
 	color: var(--black1);
 }
 
-.controversial {
+/*.controversial {
 	color: var(--red) !important;
-}
+}*/
 
 a {
 	color: var(--blue);

--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -4648,10 +4648,11 @@ img[pat][src^="/pp/"], img[pat][src$="/pic"] {
 	margin-bottom: 9.8px;
 	padding-bottom: 7px;
 }
-.controversial {
+
+/*.controversial {
 	color: #f27d0c !important;
 	font-weight: 800;
-}
+}*/
 
 code {
 	text-transform: none !important;

--- a/files/helpers/const.py
+++ b/files/helpers/const.py
@@ -72,6 +72,8 @@ PUSHER_KEY = environ.get("PUSHER_KEY", "").strip()
 DEFAULT_COLOR = environ.get("DEFAULT_COLOR", "fff").strip()
 COLORS = {'ff66ac','805ad5','62ca56','38a169','80ffff','2a96f3','eb4963','ff0000','f39731','30409f','3e98a7','e4432d','7b9ae4','ec72de','7f8fa6', 'f8db58','8cdbe6', DEFAULT_COLOR}
 
+LOGGEDIN_ACTIVE_TIME = 15 * 60
+
 AWARDS = {
 	"ghost": {
 		"kind": "ghost",

--- a/files/routes/admin.py
+++ b/files/routes/admin.py
@@ -764,6 +764,25 @@ def users_list(v):
 						   page=page,
 						   )
 
+
+@app.get('/admin/loggedin')
+@admin_level_required(2)
+def loggedin_list(v):
+	ids = [x for x, val in cache.get(f'{SITE}_loggedin').items() \
+		if (time.time() - val) < LOGGEDIN_ACTIVE_TIME]
+	users = g.db.query(User).filter(User.id.in_(ids)) \
+		.order_by(User.admin_level.desc(), User.truecoins.desc()).all()
+	return render_template("admin/loggedin.html", v=v, users=users)
+
+
+@app.get('/admin/loggedout')
+@admin_level_required(2)
+def loggedout_list(v):
+	users = sorted([val[1] for x, val in cache.get(f'{SITE}_loggedout').items() \
+		if (time.time() - val[0]) < LOGGEDIN_ACTIVE_TIME])
+	return render_template("admin/loggedout.html", v=v, users=users)
+
+
 @app.get("/admin/alt_votes")
 @admin_level_required(2)
 def alt_votes_get(v):

--- a/files/routes/feeds.py
+++ b/files/routes/feeds.py
@@ -27,7 +27,7 @@ def feeds_front(sort='hot', t='all'):
 	doc, tag, text = Doc().tagtext()
 	with tag("feed", ("xmlns:media","http://search.yahoo.com/mrss/"), xmlns="http://www.w3.org/2005/Atom",):
 		with tag("title", type="text"):
-			text(f"{sort} posts from {SITE}")
+			text(f"{sort} posts from {SITE_TITLE}")
 
 		with tag("id"):
 			text(SITE_FULL + request.full_path)

--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -353,18 +353,6 @@ def downvoting(v, username):
 	return render_template("voters.html", v=v, users=users[:25], pos=pos, name='Down', name2=f'Who @{username} downvotes')
 
 
-
-@app.post("/@<username>/suicide")
-@limiter.limit("1/second;5/day")
-@auth_required
-def suicide(v, username):
-	user = get_user(username)
-	suicide = f"Hi there,\n\nA [concerned user](/id/{v.id}) reached out to us about you.\n\nWhen you're in the middle of something painful, it may feel like you don't have a lot of options. But whatever you're going through, you deserve help and there are people who are here for you.\n\nThere are resources available in your area that are free, confidential, and available 24/7:\n\n- Call, Text, or Chat with Canada's [Crisis Services Canada](https://www.crisisservicescanada.ca/en/)\n- Call, Email, or Visit the UK's [Samaritans](https://www.samaritans.org/)\n- Text CHAT to America's [Crisis Text Line](https://www.crisistextline.org/) at 741741.\nIf you don't see a resource in your area above, the moderators keep a comprehensive list of resources and hotlines for people organized by location. Find Someone Now\n\nIf you think you may be depressed or struggling in another way, don't ignore it or brush it aside. Take yourself and your feelings seriously, and reach out to someone.\n\nIt may not feel like it, but you have options. There are people available to listen to you, and ways to move forward.\n\nYour fellow users care about you and there are people who want to help."
-	send_notification(user.id, suicide)
-	g.db.commit()
-	return {"message": "Help message sent!"}
-
-
 @app.get("/@<username>/coins")
 @auth_required
 def get_coins(v, username):

--- a/files/templates/admin/admin_home.html
+++ b/files/templates/admin/admin_home.html
@@ -8,7 +8,13 @@
 {% block content %}
 <pre></pre>
 <pre></pre>
-<h3>&nbsp;Admin Tools</h3>
+<h3>Admin Tools</h3>
+
+<div class="mb-3">
+	<strong>Users Here Now:</strong> {{g.loggedin_counter + g.loggedout_counter}} &mdash; 
+	<a href="/admin/loggedin">{{g.loggedin_counter}} Logged-In</a> | 
+	<a href="/admin/loggedout">{{g.loggedout_counter}} Logged-Out</a>
+</div>
 
 <h4>Content</h4>
 <ul>

--- a/files/templates/admin/loggedin.html
+++ b/files/templates/admin/loggedin.html
@@ -1,0 +1,21 @@
+{% extends "settings2.html" %}
+
+{% block content %}
+<div class="overflow-x-auto"><table class="table table-striped mb-5">
+<thead class="bg-primary text-white">
+	<tr>
+		<th>#</th>
+		<th>Name</th>
+		<th>Truescore</th>
+	</tr>
+</thead>
+{% for user in users %}
+	<tr>
+		<td>{{loop.index}}</td>
+		<td><a style="color:#{{user.name_color}}" href="/@{{user.username}}"><img loading="lazy" src="{{user.profile_url}}" class="pp20"><span {% if user.patron %}class="patron" style="background-color:#{{user.name_color}}"{% endif %}>{{user.username}}</span></a></td>
+		<td>{{user.truecoins}}</td>
+	</tr>
+{% endfor %}
+</table>
+
+{% endblock %}

--- a/files/templates/admin/loggedout.html
+++ b/files/templates/admin/loggedout.html
@@ -1,0 +1,19 @@
+{% extends "settings2.html" %}
+
+{% block content %}
+<div class="overflow-x-auto"><table class="table table-striped mb-5">
+<thead class="bg-primary text-white">
+	<tr>
+		<th>#</th>
+		<th>Details</th>
+	</tr>
+</thead>
+{% for user in users %}
+	<tr>
+		<td>{{loop.index}}</td>
+		<td>{{user}}</td>
+	</tr>
+{% endfor %}
+</table>
+
+{% endblock %}

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -58,12 +58,13 @@
 				{% endif %}
 			{% endif %}
 			
-			{% if not err %}
-				<a class="mobile-nav-icon d-md-none" href="/random_user" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random User"><i class="fas fa-user-circle align-middle text-gray-500 black"></i></a>
-				<a class="mobile-nav-icon d-md-none" href="/random_post" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random Post"><i class="fas fa-random align-middle text-gray-500 black"></i></a>
-			{% if v and v.admin_level > 1 %}
+		{% if not err %}
+
+			{% if v and v.admin_level >= 2 %}
 				<a class="mobile-nav-icon d-md-none" href="/admin" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Admin Tools"><i class="fas fa-crown align-middle text-gray-500 black"></i></a>
 			{% endif %}
+				<a class="mobile-nav-icon d-md-none" href="/random_user" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random User"><i class="fas fa-user-circle align-middle text-gray-500 black"></i></a>
+				<a class="mobile-nav-icon d-md-none" href="/random_post" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random Post"><i class="fas fa-random align-middle text-gray-500 black"></i></a>
 
 			{% if v %}
 				<a class="mobile-nav-icon d-md-none" href="{% if sub %}/h/{{sub.name}}{% endif %}/submit" data-bs-toggle="tooltip" data-bs-placement="bottom" title="New Post"><i class="fas fa-edit align-middle text-gray-500 black"></i></a>
@@ -79,22 +80,7 @@
 		<div class="collapse navbar-collapse" id="navbarResponsive">
 			<ul class="navbar-nav ml-auto d-none d-md-flex">
 
-				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
-					<a class="nav-link" href="/random_user/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random User"><i class="fas fa-user-circle"></i></a>
-				</li>
-
-				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
-					<a class="nav-link" href="/random_post/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random Post"><i class="fas fa-random"></i></a>
-				</li>
-
-				{% if v and v.admin_level > 1 %}
-				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
-					<a class="nav-link" href="/admin/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Admin Tools"><i class="fas fa-crown{% if v.has_report_queue %} text-success{% endif %}"></i></a>
-				</li>
-				{% endif %}
-
-				{% if v %}
-
+			{% if v %}
 				{% if v.notifications_count %}
 
 				<li class="nav-item d-flex align-items-center text-center justify-content-center mx-1">
@@ -108,18 +94,33 @@
 				</li>
 
 				{% endif %}
+			{% endif %}
+
+			{% if v and v.admin_level >= 2 %}
+				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
+					<a class="nav-link" href="/admin/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Admin Tools"><i class="fas fa-crown{% if v.has_report_queue %} text-success{% endif %}"></i></a>
+				</li>
+			{% endif %}
+
+				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
+					<a class="nav-link" href="/random_user/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random User"><i class="fas fa-user-circle"></i></a>
+				</li>
+
+				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
+					<a class="nav-link" href="/random_post/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Random Post"><i class="fas fa-random"></i></a>
+				</li>
 
 				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
 					<a class="nav-link" href="/comments" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Comments"><i class="fas fa-comment-dots"></i></a>
 				</li>
 
-				{% if v and v.admin_level > 1 %}
+			{% if v and v.admin_level >= 2 %}
 				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
 					<a class="nav-link" href="/leaderboard" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Users"><i class="fas fa-trophy"></i></a>
 				</li>
-
-				{% endif %}
+			{% endif %}
 			
+			{% if v %}
 				<li class="nav-item d-flex align-items-center justify-content-center text-center mx-1">
 					<a class="nav-link" href="{% if sub %}/h/{{sub.name}}{% endif %}/submit" data-bs-toggle="tooltip" data-bs-placement="bottom" title="New Post"><i class="fas fa-edit"></i></a>
 				</li>
@@ -136,37 +137,36 @@
 						</div>
 					</a>
 					<div id="account-menu" class="dropdown-menu dropdown-menu-right dropdown-menu-lg-left border-0 shadow fade px-0">
-					<div class="px-2">
-						<a class="dropdown-item" href="{{v.url}}"><i class="fas fa-user-circle fa-fw mr-3"></i>My
-							profile</a>
-								<a class="dropdown-item" href="/settings"><i class="fas fa-cog fa-fw mr-3"></i>Settings</a>
-							</div>
+						<div class="px-2">
+							<a class="dropdown-item" href="{{v.url}}"><i class="fas fa-user-circle fa-fw mr-3"></i>My Profile</a>
+							<a class="dropdown-item" href="/settings"><i class="fas fa-cog fa-fw mr-3"></i>Settings</a>
+						</div>
 							<div class="px-2">
-								<button class="dropdown-item copy-link" data-clipboard-text="{{SITE_FULL}}/signup?ref={{v.username}}"><i class="fas fa-user-friends fa-fw mr-3"></i>Invite friends</button>
+								<button class="dropdown-item copy-link" data-clipboard-text="{{SITE_FULL}}/signup?ref={{v.username}}"><i class="fas fa-user-friends fa-fw mr-3"></i>Invite Friends</button>
 							</div>
 							<div class="px-2">
 								<a class="dropdown-item" href="/changelog"><i class="fas fa-clipboard fa-fw mr-3"></i>Changelog</a>
 
-								<a class="dropdown-item" rel="nofollow noopener noreferrer" href="https://github.com/themotte/rDrama"><i class="fab fa-github fa-fw mr-3"></i>Source code</a>
+								<a class="dropdown-item" rel="nofollow noopener noreferrer" href="https://github.com/themotte/rDrama"><i class="fab fa-github fa-fw mr-3"></i>Source Code</a>
 
-								<a class="dropdown-item" href="/contact"><i class="fas fa-file-signature fa-fw mr-3"></i>Contact us</a>
+								<a class="dropdown-item" href="/contact"><i class="fas fa-file-signature fa-fw mr-3"></i>Contact Us</a>
 							</div>
 							<div class="px-2">
-								<a class="dropdown-item" role="button" href="/logout"><i class="fas fa-sign-out fa-fw mr-3"></i>Log out</a>
+								<a class="dropdown-item" role="button" href="/logout"><i class="fas fa-sign-out fa-fw mr-3"></i>Log Out</a>
 							</div>
 						</div>
 					</div>
 				</li>
-				{% else %}
+			{% else %}
 				<li class="nav-item d-flex align-items-center justify-content-center mx-1">
-				<a class="btn btn-primary" href="/contact">Contact us</a>
-			</li>
+					<a class="btn btn-primary" href="/contact">Contact Us</a>
+				</li>
 				<li class="nav-item d-flex align-items-center justify-content-center mx-1">
-				<a class="btn btn-primary" href="/login?redirect={{request.path | urlencode}}">Sign in</a>
-			</li>
-			<li class="nav-item d-flex align-items-center justify-content-center mx-1">
-				<a class="btn btn-primary" href="/signup">Sign up</a>
-			</li>
+					<a class="btn btn-primary" href="/login?redirect={{request.path | urlencode}}">Sign In</a>
+				</li>
+				<li class="nav-item d-flex align-items-center justify-content-center mx-1">
+					<a class="btn btn-primary" href="/signup">Sign Up</a>
+				</li>
 			{% endif %}
 		</ul>
 
@@ -190,26 +190,26 @@
 				</li>
 				{% if not g.webview %}
 					<li class="nav-item">
-						<a class="nav-link copy-link" data-clipboard-text="{{SITE_FULL}}/signup?ref={{v.username}}"><i class="fas fa-user-friends fa-fw mr-3"></i>Invite friends</a>
+						<a class="nav-link copy-link" data-clipboard-text="{{SITE_FULL}}/signup?ref={{v.username}}"><i class="fas fa-user-friends fa-fw mr-3"></i>Invite Friends</a>
 					</li>
 				{% endif %}
 				
-				<a class="nav-item nav-link" rel="nofollow noopener noreferrer" href="https://github.com/themotte/rDrama"><i class="fab fa-github fa-fw mr-3"></i>Source code</a>
+				<a class="nav-item nav-link" rel="nofollow noopener noreferrer" href="https://github.com/themotte/rDrama"><i class="fab fa-github fa-fw mr-3"></i>Source Code</a>
 
-				<a class="nav-item nav-link" href="/contact"><i class="fas fa-file-signature fa-fw mr-3"></i>Contact us</a>
+				<a class="nav-item nav-link" href="/contact"><i class="fas fa-file-signature fa-fw mr-3"></i>Contact Us</a>
 
 				<li class="nav-item border-top border-bottom mt-2 pt-2">
-					<a class="nav-link" role="button" href="/logout"><i class="fas fa-sign-out fa-fw mr-3 text-danger"></i>Log out</a>
+					<a class="nav-link" role="button" href="/logout"><i class="fas fa-sign-out fa-fw mr-3 text-danger"></i>Log Out</a>
 				</li>
 			{% else %}
 				<li class="nav-item d-flex align-items-center justify-content-center pb-3">
-					<a class="btn btn-primary btn-block" href="/contact">Contact us</a>
+					<a class="btn btn-primary btn-block" href="/contact">Contact Us</a>
 				</li>
 				<li class="nav-item d-flex align-items-center justify-content-center pb-3">
-					<a class="btn btn-primary btn-block" href="/login?redirect={{request.path | urlencode}}">Sign in</a>
+					<a class="btn btn-primary btn-block" href="/login?redirect={{request.path | urlencode}}">Sign In</a>
 				</li>
 				<li class="nav-item d-flex align-items-center justify-content-center">
-					<a class="btn btn-primary btn-block" href="/signup">Sign up</a>
+					<a class="btn btn-primary btn-block" href="/signup">Sign Up</a>
 				</li>
 			{% endif %}
 			<li class="mt-3">

--- a/files/templates/submission_listing.html
+++ b/files/templates/submission_listing.html
@@ -162,7 +162,7 @@
 
 				<div class="post-info text-left">
 					<div class="post-author">
-						<span class="post-traffic-info d-none d-md-inline-block"><a href="{{p.permalink}}">{{p.comment_count}} comments</a> - {{p.views}} thread views</span>
+						<span class="post-traffic-info d-none d-md-inline-block"><a href="{{p.permalink}}">{{p.comment_count}} comments</a><span class="text-info d-none {{p.id}}-new-comments"></span> - {{p.views}} thread views</span>
 
 						{% if p.bannedfor %}
 							<a role="button"><i class="fas fa-hammer-crash text-danger" data-bs-toggle="tooltip" data-bs-placement="bottom" title="User was banned for this post{% if p.author.banned_by %} by @{{p.author.banned_by.username}}{% endif %}"></i></a>

--- a/files/templates/userpage.html
+++ b/files/templates/userpage.html
@@ -165,8 +165,6 @@
 						<a id="button-sub" class="btn btn-primary {% if is_following or u.is_nofollow or u.is_blocked %}d-none{% endif %}" role="button" onclick="post_toast2(this,'/follow/{{u.username}}','button-unsub','button-sub')">Follow</a>						
 						<a class="btn btn-primary" role="button" onclick="toggleElement('message', 'input-message')">Message</a>
 
-						<a class="btn btn-primary" role="button" onclick="post_toast(this,'/@{{u.username}}/suicide')">Get them help</a>
-
 						{% if v and v.admin_level > 2 %}
 							<a id="admin" class="{% if u.admin_level > 1 %}d-none{% endif %} btn btn-primary" href="javascript:void(0)" onclick="post_toast2(this,'/@{{u.username}}/make_admin','admin','unadmin')">Make admin</a>
 
@@ -440,7 +438,6 @@
 
 					<a id="button-sub2" class="btn btn-primary {% if is_following or u.is_nofollow or u.is_blocked %}d-none{% endif %}" role="button" onclick="post_toast2(this,'/follow/{{u.username}}','button-unsub2','button-sub2')">Follow</a>						
 					<a class="btn btn-primary" role="button" onclick="toggleElement('message-mobile', 'input-message-mobile')">Message</a>
-					<a class="btn btn-primary" role="button" onclick="post_toast(this,'/@{{u.username}}/suicide')">Get them help</a>
 
 					{% if v and v.admin_level > 2 %} 
 						<a id="admin2" class="{% if u.admin_level > 1 %}d-none{% endif %} btn btn-primary" href="javascript:void(0)" onclick="post_toast2(this,'/@{{u.username}}/make_admin','admin2','unadmin2')">Make admin</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ qrcode
 redis
 requests
 SQLAlchemy
+user-agents
 psycopg2-binary
 pusher_push_notifications
 pyenchant


### PR DESCRIPTION
Grab-bag of fixes and things ported in from upstream. Didn't really want to break it into a bunch of PRs. In order of time committed:

950a2a3bbed8a1310867e72a691733e1b55b8600 — Ports in `routes/feeds.py` from upstream. Saw someone mention on the site that they'd visit more if they had working RSS. The RSS had highly non-standard markup, which was fixed not long after TheMotte forked. This ports in changes from the upstream to make it valid.

c7052e8b3079a91a05da553df8403a26d2947977 — Fixes #238. Removes "Get Them Help" button and route.

e1ba2866dc2cadd0498e5f33a9887e813752fae7 — Ports in improvements from upstream to provide counters and listings of logged-in/logged-out users to have an idea of site traffic. Currently only presented in the admin panel.

efac770ad31ebfe4510f6270b2f029eb9f52e790 — Reorders header icons so the notifications bell is always at the left. This commit touches a lot more lines than it ought to because the indentation in header.html is perennially kind of a mess, sorry.

c9cbffd1593188a4071838b9897ec5ddca90e5b0 — Fixes #245. Removes the CSS rules for `.controversial` so controversial comments don't have reddish-orange vote counts.

3141ac03f33b8647187b94735eabd8927c59d688 — Fixes #246. The logic to provide new comment count indicators on submission_listings was all there, and it was already functional on mobile! The element on desktop got removed at some point, though.

P.S. If there are any deployment issues, make sure to `pip3 install -r requirements.txt` because the active user counter commit adds a dependency on the `user-agents` package. 