### PR TITLE
Fix short child comments auto-collapsing.

### DIFF
--- a/files/classes/comment.py
+++ b/files/classes/comment.py
@@ -392,8 +392,6 @@ class Comment(Base):
 		if self.over_18 and not (v and v.over_18) and not (self.post and self.post.over_18): return True
 
 		if self.is_banned: return True
-
-		if path.startswith('/post') and (not self.body or len(self.body_html) <= 100) and 9 > self.level > 1: return True
 			
 		if v and v.filter_words and self.body and any(x in self.body for x in v.filter_words): return True
 		


### PR DESCRIPTION
Bug accidentally introduced with 70c8a942b6f8, when a removed clause in Comment.collapse_for_user was treated as always True, rather than as always False--which would've removed this entire line, as this commit does now.

Original intent of the logic was for auto-collapsing game comments like blackjack and slots that necessarily entailed somewhat spammy commenting behavior.