### PR TITLE
Clean up handling of "view more comments" button

### DIFF
--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -38,9 +38,9 @@
 		</div>
 		</div>
 	</div>
-{% endif %}
 
-{% include 'usernote.html' %}
+  {% include 'usernote.html' %}
+{% endif %}
 
 {% macro single_comment(c, level=1) %}
 
@@ -741,6 +741,16 @@
 
 {% endfor %}
 
+{% if offset %}
+	{% if p %}
+		{% set pid = p.id %}
+	{% endif %}
+	<div id="viewmore-{{offset}}">
+		<br>
+		<button id="viewbtn" class="btn btn-primary" onclick="viewmore({{pid}},'{{sort}}',{{offset}},{{ids}})">VIEW MORE COMMENTS</button>
+	</div>
+{% endif %}
+
 {% if not ajax %}
 	{% if v %}
 		{% include "gif_modal.html" %}
@@ -887,14 +897,6 @@
 			xhr.send(form)
 		}
 	</script>
-{% endif %}
-
-{% if offset %}
-	{% if p %}
-		{% set pid = p.id %}
-	{% endif %}
-	<br>
-	<div id="viewmore-{{offset}}"><button id="viewbtn" class="btn btn-primary" onclick="viewmore({{pid}},'{{sort}}',{{offset}},{{ids}})">VIEW MORE COMMENTS</a></div>
 {% endif %}
 
 </body>

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -539,9 +539,11 @@
 			xhr.setRequestHeader('xhr', 'xhr');
 			xhr.onload=function(){
 				if (xhr.status==200) {
-					let e = document.getElementById(`viewmore-${offset}`);
-					e.innerHTML = xhr.response.replace(/data-src/g, 'src').replace(/data-cfsrc/g, 'src').replace(/style="display:none;visibility:hidden;"/g, '');
-					bs_trigger(e)
+					const e = document.getElementById(`viewmore-${offset}`);
+					const html = xhr.response.replace(/data-src/g, "src").replace(/data-cfsrc/g, "src").replace(/style="display:none;visibility:hidden;"/g, "");
+					const fragment = document.createRange().createContextualFragment(html);
+					bs_trigger(fragment);
+					e.replaceWith(fragment);
 
 					comments = JSON.parse(localStorage.getItem("old-comment-counts")) || {}
 					lastCount = comments['{{p.id}}']


### PR DESCRIPTION
It was bothering me that the "view more comments" button left a gap between the prior comments and the newly loaded comments, so I changed it to load the new comments in place instead of as children. (I asked Aevann about this a while back, but apparently he prefers to leave the gap.) Also, each new page of comments was including a new copy of the usernote element, so I put that behind an `{% if not ajax %}` block. It seems like the usernote button won't work for any comment following the original page, regardless of this change; I'm not sure how to fix it, since it's a fundamental weakness in the interface of Micromodal.js that it only can register event handlers exactly once.