### PR TITLE
Implement client-side collapsed comment memory.

### DIFF
--- a/files/assets/js/comments.js
+++ b/files/assets/js/comments.js
@@ -1,5 +1,30 @@
+var closedCommentsKey = null;
+var closedComments = [];
+
+function collapsedCommentStorageInit(pageKey) {
+	closedCommentsKey = `closedcomments_${pageKey}`;
+}
+
+function collapsedCommentStorageApply() {
+	if (!closedCommentsKey) {
+		return;
+	}
+
+	var closedCommentsValue = localStorage.getItem(closedCommentsKey);
+	if (closedCommentsValue === null) {
+		closedComments = [];
+	} else {
+		closedComments = JSON.parse(closedCommentsValue);
+	}
+
+	closedComments.forEach((commentId) => {
+		try {
+			document.getElementById(`comment-${commentId}`).classList.add("collapsed");
+		} catch (e) {}
+	})
+}
+
 function collapse_comment(id, element) {
-	console.log(element)
 	const closed = element.classList.toggle("collapsed")
 	const top = element.getBoundingClientRect().y
 
@@ -10,6 +35,15 @@ function collapse_comment(id, element) {
 
 	const flags = document.getElementById(`flaggers-${id}`)
 	if (flags) flags.classList.add('d-none')
+
+	if (closed && !closedComments.includes(id)) {
+		closedComments.push(id);
+	} else if (!closed && closedComments.includes(id)) {
+		closedComments.splice(closedComments.indexOf(id), 1);
+	}
+	if (closedCommentsKey) {
+		localStorage.setItem(closedCommentsKey, JSON.stringify(closedComments));
+	}
 };
 
 function expandMarkdown(t,id) {

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -861,6 +861,17 @@
 			}
 		{% endif %}
 
+		{% if p %}
+			collapsedCommentStorageInit('post_{{p.id}}');
+		{% elif request.path == '/notifications' or request.path.startswith('/@') %}
+			collapsedCommentStorageInit('{{request.path}}');
+		{% endif %}
+		if (document.readyState === "complete" || 
+				(document.readyState !== "loading" && !document.documentElement.doScroll)) {
+			collapsedCommentStorageApply();
+		} else {
+			document.addEventListener("DOMContentLoaded", collapsedCommentStorageApply);
+		}
 
 		function morecomments(cid) {
 			btn = document.getElementById(`btn-${cid}`);

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -557,6 +557,8 @@
 							{% endif %}
 						{% endfor %}
 					}
+
+					collapsedCommentStorageApply();
 				}
 				btn.disabled = false;
 			}


### PR DESCRIPTION
Fixes #290. h/t Suspicious Turtle for initial implementation.

Tested and working on post pages, /notifications, and userpage comment listings (all independently collapsible) and disables itself gracefully in other contexts where comments are used.