### PR TITLE
De-float navigation menu

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -2620,7 +2620,6 @@ pre {
 	word-wrap: break-word;
 }
 #settings, #submit {
-	padding-top: 98px;
 	background-color: var(--gray-600);
 }
 #page {
@@ -4071,11 +4070,6 @@ pre .com, code .com {
 	border: 3px solid var(--primary);
 	border-radius: 0.35rem;
 }
-@media (max-width: 991.98px) {
-	body {
-		padding-top: 72px;
-}
-}
 
 @media (max-width: 767.98px) {
 	html {
@@ -4498,14 +4492,6 @@ textarea {
 }
 .container, .container-fluid {
 	padding-bottom: 50px;
-}
-.navbar {
-	padding: 0.2rem 0 0 0.2rem;
-}
-@media (min-width: 767.98px) {
-	.navbar {
-		padding: 0.5rem 1.5rem 0.4rem 0.5rem;
-}
 }
 blockquote {
 	border-left: 2px solid var(--primary);

--- a/files/templates/default.html
+++ b/files/templates/default.html
@@ -212,6 +212,8 @@
 
  <body id="{% if request.path != '/comments' %}{% block pagetype %}frontpage{% endblock %}{% endif %}" {% if v and v.background %}style="{% if path != '/formatting' %}overflow-x: hidden; {% endif %} background:url(/assets/images/backgrounds/{{v.background}}?v=3) center center fixed; background-color: var(--background){% if 'anime' not in v.background %};background-size: cover{% endif %}"{% endif %}>
 
+{% include "header.html" %}
+
 {% block Banner %}
 	{% if '@' not in request.path %}		
 		{% if sub %}
@@ -223,8 +225,6 @@
 		{% endif %}
 	{% endif %}
 {% endblock %}
-
-{% include "header.html" %}
 
 {% block mobileUserBanner %}
 {% endblock %}

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -1,15 +1,6 @@
 
-<nav id="main-navigation" class="shadow shadow-md fixed-top">
-	<style>
-		body {padding-top: 60.89px !important}
-		@media (max-width: 767.98px) {
-			body {
-				padding-top: 44.55px !important
-			}
-		}
-	</style>
-
-	<div class="navbar navbar-expand-md navbar-light" id="navbar">
+<nav id="main-navigation" class="shadow shadow-md">
+	<div class="navbar navbar-expand-md" id="navbar">
 		<div class="container-fluid" style="padding:0;">
 			<a href="/" class="navbar-brand mr-auto">
 				<img alt="header icon" height=33 src="{{ ('images/'~SITE_ID~'/headericon.webp') | asset }}">

--- a/files/templates/search.html
+++ b/files/templates/search.html
@@ -84,7 +84,7 @@
 
 {% if not '/users/' in request.path %}
 
-<div class="flex-row tab-bar sticky d-none">
+<div class="flex-row tab-bar d-none">
 
 	<ul class="nav post-nav mr-auto">
 		<li class="nav-item">

--- a/files/templates/settings.html
+++ b/files/templates/settings.html
@@ -83,7 +83,7 @@
 
 		
 		
-		<div class="flex-row bg-white box-shadow-bottom sticky d-none d-sm-flex mt-3 mb-3 mb-sm-5">
+		<div class="flex-row bg-white box-shadow-bottom d-none d-sm-flex mt-3 mb-3 mb-sm-5">
 
 			<ul class="nav settings-nav">
 				<li class="nav-item">
@@ -112,7 +112,7 @@
 		</div>
 
 		
-		<div class="flex-row bg-white box-shadow-bottom sticky justify-content-center d-flex d-sm-none mt-3 mb-3 mb-sm-5">
+		<div class="flex-row bg-white box-shadow-bottom justify-content-center d-flex d-sm-none mt-3 mb-3 mb-sm-5">
 
 			<ul class="nav settings-nav">
 				<li class="nav-item">

--- a/files/templates/settings2.html
+++ b/files/templates/settings2.html
@@ -55,7 +55,7 @@
 {% block subNav %}
 
 {% set mod = (v and v.admin_level > 1) %}
-<div class="container-fluid bg-white sticky d-none d-md-block" style="padding-top: 50px; padding-bottom: 0 !important;">
+<div class="container-fluid bg-white d-none d-md-block" style="padding-top: 50px; padding-bottom: 0 !important;">
 	<div class="row box-shadow-bottom">
 			<div class="col">
 				<div class="container" style="padding-bottom: 0;">
@@ -105,7 +105,7 @@
 			</div>
 		</div>
 	</div>
-		<div class="container-fluid bg-white sticky d-md-none" style="padding-top: 20px; padding-bottom: 0; margin-bottom: 20px;">
+		<div class="container-fluid bg-white d-md-none" style="padding-top: 20px; padding-bottom: 0; margin-bottom: 20px;">
 		<div class="row box-shadow-bottom">
 			<div class="col px-0">
 				<div class="d-flex flex-row-reverse justify-content-center">


### PR DESCRIPTION
I think I've sorted out the git history, finally. This PR should resolve #234 .

EDIT: while test driving the changes one last time I found navigation menus on the settings page that used the `.sticky` class to stay at the top of the screen, offset to leave space for the main menu. I removed them as well.