### PR TITLE
Fix #321: integer out-of-bounds when sorting by 'hot'.

### DIFF
--- a/files/routes/feeds.py
+++ b/files/routes/feeds.py
@@ -12,7 +12,7 @@ from files.__main__ import app
 @app.get('/rss')
 @app.get('/feed')
 @app.get('/rss/<sort>/<t>')
-def feeds_front(sort='hot', t='all'):
+def feeds_front(sort='new', t='all'):
 	try: page = max(int(request.values.get("page", 1)), 1)
 	except: page = 1
 

--- a/files/routes/front.py
+++ b/files/routes/front.py
@@ -287,7 +287,7 @@ def front_all(v, sub=None, subdomain=None):
 
 
 @cache.memoize(timeout=86400)
-def frontlist(v=None, sort="hot", page=1, t="all", ids_only=True, ccmode="false", filter_words='', gt=0, lt=0, sub=None, site=None):
+def frontlist(v=None, sort='new', page=1, t="all", ids_only=True, ccmode="false", filter_words='', gt=0, lt=0, sub=None, site=None):
 
 	posts = g.db.query(Submission)
 	

--- a/files/routes/front.py
+++ b/files/routes/front.py
@@ -340,11 +340,13 @@ def frontlist(v=None, sort='new', page=1, t="all", ids_only=True, ccmode="false"
 	if not (v and v.shadowbanned):
 		posts = posts.join(User, User.id == Submission.author_id).filter(User.shadowbanned == None)
 
-	num = 1
-
 	if sort == "hot":
 		ti = int(time.time()) + 3600
-		posts = posts.order_by(-1000000*(Submission.realupvotes + 1 + Submission.comment_count/num + (func.length(Submission.body_html)-func.length(func.replace(Submission.body_html,'</a>','')))/4)/(func.power(((ti - Submission.created_utc)/1000), 1.23)), Submission.created_utc.desc())
+		posts = posts.order_by(
+					-100000
+						* (Submission.realupvotes + 1 + Submission.comment_count / 10)
+						/ (func.power((ti - Submission.created_utc) / 1000, 1.23)),
+					Submission.created_utc.desc())
 	elif sort == "bump":
 		posts = posts.filter(Submission.comment_count > 1).order_by(Submission.bump_utc.desc(), Submission.created_utc.desc())
 	elif sort == "new":

--- a/files/templates/settings_profile.html
+++ b/files/templates/settings_profile.html
@@ -228,9 +228,9 @@
 
 							<div class="body w-lg-100">
 
-								<input autocomplete="off" type="text" readonly="" class="form-control copy-link" id="rss_feed" value="{{SITE_FULL}}/rss/hot/all" data-clipboard-text="{{SITE_FULL}}/rss/hot/all">
+								<input autocomplete="off" type="text" readonly="" class="form-control copy-link" id="rss_feed" value="{{SITE_FULL}}/rss/new/all" data-clipboard-text="{{SITE_FULL}}/rss/new/all">
 
-								<div class="text-small-extra text-muted mt-3">You can change the feed by replacing "hot" with whatever sorting you want and "all" with whatever time filter you want.</div>
+								<div class="text-small-extra text-muted mt-3">You can change the feed by replacing "new" with whatever sorting you want and "all" with whatever time filter you want.</div>
 
 							</div>
 


### PR DESCRIPTION
First, switches RSS feeds to default to 'new' rather than 'hot' sort, as this better matches how a feed of posts ought to behave on TheMotte (since the frontpage also defaults to new). Ultimately incidental to the fix, though. Included because originally believed this was an RSS feeds bug.

---

Primary bug:

Fixes #321. Due to the extremely large quantity of comments on a typical Motte post, 'hot' sorting logic underflowed an intermediate value. Roughly (for /post/2, last week's CWR thread):
    
    |(-1 000 000) * (103 [votes] + 1 + 2723 [comments] / 1)| > 2^31
    
We resolve this by reducing the coefficient from 1e6 to 1e5, which reduces precision of intermediate calculations somewhat, and by dividing #comments by 10 rather than 1, which better matches Motte user behavior regardless: users comment much more often than vote. This buys us two orders of magnitude more headroom before out-of-bounds. Shouldn't be an issue until the CW thread reaches ~200k comments.