### PR TITLE
[#336] Remove CSS that breaks nested lists in comments

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -2680,9 +2680,6 @@ pre {
 a.dropdown-toggle:hover {
 	text-decoration: none;
 }
-.comment-text ul li ul {
-	padding-left: 0;
-}
 .comment-text a {
 	text-decoration: underline;
 }


### PR DESCRIPTION
Removes the offending CSS.

I'm not sure _why_ it was put in there, but that CSS [predates](https://github.com/Butonix/ruqqus-1/commit/1661e3d2b926296afc88c9a3490873d086194418) the ruqqus->rDrama move. Commit message is just "nested unordered list padding". I would not be surprised if added to "fix" an issue where for some reason each list item was being added as a child rather than a sibling of the previous list item, but I don't see anywhere that would actually do that.

Since I don't know why this was originally added, it's possible that removing it will cause formatting issues somewhere else down the line. A cursory search didn't turn up anything like that though, and a `document.querySelectorAll('ul ul')` on the [page](https://www.themotte.org/post/30/bugs-suggestions-small-comments-and-site) which triggered the bug report turned up only the sidebar (which doesn't match the css rule) and the comment that was the example of the rendering bug.


| Without fix | With fix |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/95843830/190839955-588efba2-a0cb-4c90-b913-7438f485f0ec.png) | ![image](https://user-images.githubusercontent.com/95843830/190839987-0df85ece-cb3b-4b31-9086-8947c0a89f0e.png) |

