### PR TITLE
Use Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,4 @@ RUN mkdir /images && mkdir /songs
 EXPOSE 80/tcp
 
 CMD [ "/usr/bin/supervisord", "-c", "/etc/supervisord.conf" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:22.04
+FROM python:3.11
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# python3-cachecontrol is currently required due to a dependency error in ubuntu 22.04's python3-poetry package
-RUN apt update && apt -y upgrade && apt install -y supervisor python3-poetry ffmpeg python3-cachecontrol
+RUN apt update && apt -y upgrade && apt install -y supervisor ffmpeg 
 
 COPY supervisord.conf /etc/supervisord.conf
 
@@ -11,6 +10,7 @@ COPY supervisord.conf /etc/supervisord.conf
 WORKDIR /service
 COPY pyproject.toml .
 COPY poetry.lock .
+RUN pip install 'poetry==1.2.2'
 RUN poetry config virtualenvs.create false && poetry install
 
 RUN mkdir /images && mkdir /songs

--- a/poetry.lock
+++ b/poetry.lock
@@ -1018,7 +1018,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.10"
+python-versions = "^3.11"
 content-hash = "2a0f266aae2676e4fb10a7cd37f657ca14bfd2c0db21f0e0cd262691ecf429ee"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <you@example.com>"]
 license = "AGPL"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 beautifulsoup4 = "*"
 bleach = "4.1.0"
 Flask = "*"


### PR DESCRIPTION
The newest version of Python has notably better performance in some cases (eg see https://jott.live/markdown/py3.11_vs_3.8) which may help overall site performance. Surprisingly this change didn't seem to break anything (and I did force-rebuild the container).