### PR TITLE
modlog: fix 500 (ported from upstream)

### DIFF
--- a/files/routes/static.py
+++ b/files/routes/static.py
@@ -244,6 +244,7 @@ def log(v=None):
 	if admin_id:
 		actions = actions.filter_by(user_id=admin_id)
 		kinds = set([x.kind for x in actions])
+		kinds.add(kind)
 		types2 = {}
 		for k,val in types.items():
 			if k in kinds: types2[k] = val


### PR DESCRIPTION
fix when clicking on an action and then clicking on an admin, if that admin doesn't have any admin actions of that specific type