### PR TITLE
Fix #261, fix #352.

### DIFF
--- a/files/routes/comments.py
+++ b/files/routes/comments.py
@@ -89,6 +89,7 @@ def post_pid_comment_cid(cid, pid=None, anything=None, v=None, sub=None):
 	comment_info = comment
 	c = comment
 	while context and c.level > 1:
+		c.parent_comment.replies2 = [c]
 		c = c.parent_comment
 		context -= 1
 	top_comment = c

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -877,7 +877,7 @@
 			}
 		{% endif %}
 
-		{% if p %}
+		{% if p and not (request.values and ('context' in request.values)) %}
 			collapsedCommentStorageInit('post_{{p.id}}');
 		{% elif request.path == '/notifications' or request.path.startswith('/@') %}
 			collapsedCommentStorageInit('{{request.path}}');


### PR DESCRIPTION
#352 — One-liner change to `templates/comments.html` to not activate the clientside comment collapse code when viewing contexts. Yes, checking the Request object is inelegant, but it's how it's done elsewhere in the code, and I think I'd have to touch a dozen files to represent that state more explicitly.

#261 — Turns out it's literally just that one line. This was much less obvious than it should've been.