### PR TITLE
Fix four routes with auth_desired misimplemented.

### DIFF
--- a/files/routes/front.py
+++ b/files/routes/front.py
@@ -468,7 +468,7 @@ def changeloglist(v=None, sort="new", page=1, t="all", site=None):
 
 @app.get("/random_post")
 @auth_desired
-def random_post():
+def random_post(v):
 
 	p = g.db.query(Submission.id).filter(Submission.deleted_utc == 0, Submission.is_banned == False, Submission.private == False).order_by(func.random()).first()
 
@@ -480,7 +480,7 @@ def random_post():
 
 @app.get("/random_user")
 @auth_desired
-def random_user():
+def random_user(v):
 	u = g.db.query(User.username).order_by(func.random()).first()
 	
 	if u: u = u[0]

--- a/files/routes/search.py
+++ b/files/routes/search.py
@@ -34,7 +34,7 @@ def searchparse(text):
 
 @app.get("/search/posts")
 @auth_desired
-def searchposts(v=None):
+def searchposts(v):
 
 	query = request.values.get("q", '').strip()
 
@@ -177,7 +177,7 @@ def searchposts(v=None):
 
 @app.get("/search/comments")
 @auth_desired
-def searchcomments(v=None):
+def searchcomments(v):
 
 
 	query = request.values.get("q", '').strip()
@@ -270,7 +270,7 @@ def searchcomments(v=None):
 
 @app.get("/search/users")
 @auth_desired
-def searchusers(v=None):
+def searchusers(v):
 
 	query = request.values.get("q", '').strip()
 

--- a/files/routes/static.py
+++ b/files/routes/static.py
@@ -60,7 +60,7 @@ def support(v):
 @app.get("/stats")
 @auth_desired
 @cache.memoize(timeout=86400, make_name=make_name)
-def participation_stats(v=None):
+def participation_stats(v):
 
 
 	day = int(time.time()) - 86400
@@ -115,14 +115,14 @@ def chart():
 
 @app.get("/weekly_chart")
 @auth_desired
-def weekly_chart():
+def weekly_chart(v):
 	file = cached_chart(kind="weekly", site=SITE)
 	f = send_file(file)
 	return f
 
 @app.get("/daily_chart")
 @auth_desired
-def daily_chart():
+def daily_chart(v):
 	file = cached_chart(kind="daily", site=SITE)
 	f = send_file(file)
 	return f
@@ -208,7 +208,7 @@ def patrons(v):
 @app.get("/admins")
 @app.get("/badmins")
 @auth_desired
-def admins(v=None):
+def admins(v):
 	if v and v.admin_level > 2:
 		admins = g.db.query(User).filter(User.admin_level>1).order_by(User.truecoins.desc()).all()
 		admins += g.db.query(User).filter(User.admin_level==1).order_by(User.truecoins.desc()).all()
@@ -219,7 +219,7 @@ def admins(v=None):
 @app.get("/log")
 @app.get("/modlog")
 @auth_desired
-def log(v=None):
+def log(v):
 
 	try: page = max(int(request.values.get("page", 1)), 1)
 	except: page = 1
@@ -261,7 +261,7 @@ def log(v=None):
 
 @app.get("/log/<id>")
 @auth_desired
-def log_item(id, v=None):
+def log_item(v, id):
 
 	try: id = int(id)
 	except: abort(404)
@@ -280,21 +280,21 @@ def log_item(id, v=None):
 
 @app.get("/api")
 @auth_desired
-def api(v=None):
+def api(v):
 	return render_template("api.html", v=v)
 
 @app.get("/contact")
 @app.get("/press")
 @app.get("/media")
 @auth_desired
-def contact(v=None):
+def contact(v):
 
 	return render_template("contact.html", v=v)
 
 @app.post("/send_admin")
 @limiter.limit("1/second;2/minute;6/hour;10/day")
 @auth_desired
-def submit_contact(v=None):
+def submit_contact(v):
 	body = request.values.get("message")
 	email = request.values.get("email")
 	if not body: abort(400)
@@ -422,14 +422,14 @@ def blocks(v):
 
 @app.get("/banned")
 @auth_desired
-def banned(v=None):
+def banned(v):
 
 	users = [x for x in g.db.query(User).filter(User.is_banned > 0, User.unban_utc == 0).all()]
 	return render_template("banned.html", v=v, users=users)
 
 @app.get("/formatting")
 @auth_desired
-def formatting(v=None):
+def formatting(v):
 
 	return render_template("formatting.html", v=v)
 

--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -753,25 +753,25 @@ def api_is_available(name):
 
 @app.get("/id/<id>")
 @auth_desired
-def user_id(id):
+def user_id(v, id):
 	user = get_account(id)
 	return redirect(user.url)
 		
 @app.get("/u/<username>")
 @auth_desired
-def redditor_moment_redirect(username):
+def redditor_moment_redirect(v, username):
 	return redirect(f"/@{username}")
 
 @app.get("/@<username>/followers")
 @auth_desired
-def followers(username, v=None):
+def followers(v, username):
 	u = get_user(username, v=v)
 	users = g.db.query(User).join(Follow, Follow.target_id == u.id).filter(Follow.user_id == User.id).order_by(Follow.created_utc).all()
 	return render_template("followers.html", v=v, u=u, users=users)
 
 @app.get("/@<username>/following")
 @auth_desired
-def following(username, v=None):
+def following(v, username):
 	u = get_user(username, v=v)
 	users = g.db.query(User).join(Follow, Follow.user_id == u.id).filter(Follow.target_id == User.id).order_by(Follow.created_utc).all()
 	return render_template("following.html", v=v, u=u, users=users)


### PR DESCRIPTION
PR #374 removed `@auth_required` from a number of routes and changed those which used their `v` parameters to `v=None` and removed the `v` parameter from those which didn't internally use it. 1841134b4742

PR #392 re-added `@auth_desired` to those routes to ensure the templates rendered with awareness of the current logged-in user (matters for search, header bar, etc). 9f042c1aeb7b

However, 500 errors occurred on `/random_post`, `/random_user`, `/id/<uid>`, and `/u/<username>`. Those were the four which had their `v` parameter removed entirely. This has been re-added, which fixes the bug.

The way to understand auth_required vs auth_desired is that they are nearly identical, with the sole difference that auth_required checks if v is None and aborts with 401 if so. This means that auth_desired routes must handle the v=None case. They are the same in that they always try to give a `v` kwarg to the decorated function, which was the root cause of those four routes erroring.

Recommended style: the vast majority of routes which return a rendered template should be auth_desired, because the top-level templates often draw extensively from `v` state even when the route handler does not. When a route is either auth_desired or auth_required, it should have a `v` parameter, which we typically give as the first positional parameter.