### PR TITLE
security: add ENFORCE_PRODUCTION

### DIFF
--- a/env
+++ b/env
@@ -2,6 +2,7 @@ MASTER_KEY=blahblahblah
 DOMAIN=localhost
 SITE_ID=TheMotte
 SITE_TITLE=The Motte
+ENFORCE_PRODUCTION=False
 GIPHY_KEY=blahblahblah
 DISCORD_SERVER_ID=blahblahblah
 DISCORD_CLIENT_ID=blahblahblah

--- a/files/__main__.py
+++ b/files/__main__.py
@@ -27,6 +27,9 @@ app.jinja_env.cache = {}
 app.jinja_env.auto_reload = True
 faulthandler.enable()
 
+if environ.get("ENFORCE_PRODUCTION", False) and app.config["DEBUG"]:
+	raise ValueError("Debug mode is not allowed! If this is a dev environment, please set ENFORCE_PRODUCTION to false")
+
 if environ.get("SITE_ID") is None:
 	from dotenv import load_dotenv
 	load_dotenv(dotenv_path=Path("env"))


### PR DESCRIPTION
can provide a safety check so debug mode never gets enabled on production environments by accident

testing hasn't been done yet but it should be pretty simple as the thing (intentionally) crashes the app relatively early