### PR TITLE
Fix: Changes to the User table cause unavoidable breakages in the Leaderboard system.

### DIFF
--- a/files/__main__.py
+++ b/files/__main__.py
@@ -28,7 +28,7 @@ app.jinja_env.cache = {}
 app.jinja_env.auto_reload = True
 faulthandler.enable()
 
-if bool_from_string(environ.get("ENFORCE_PRODUCTION", "true")) and app.config["DEBUG"]:
+if bool_from_string(environ.get("ENFORCE_PRODUCTION", True)) and app.config["DEBUG"]:
 	raise ValueError("Debug mode is not allowed! If this is a dev environment, please set ENFORCE_PRODUCTION to false")
 
 if environ.get("SITE_ID") is None:
@@ -126,6 +126,7 @@ app.config['MENTION_LIMIT'] = int(environ.get('MENTION_LIMIT', 100))
 app.config['MULTIMEDIA_EMBEDDING_ENABLED'] = environ.get('MULTIMEDIA_EMBEDDING_ENABLED', "false").lower() == "true"
 app.config['RESULTS_PER_PAGE_COMMENTS'] = int(environ.get('RESULTS_PER_PAGE_COMMENTS',50))
 app.config['SCORE_HIDING_TIME_HOURS'] = int(environ.get('SCORE_HIDING_TIME_HOURS'))
+app.config['ENABLE_SERVICES'] = bool_from_string(environ.get('ENABLE_SERVICES', False))
 
 r=redis.Redis(host=environ.get("REDIS_URL", "redis://localhost"), decode_responses=True, ssl_cert_reqs=None)
 

--- a/files/helpers/strings.py
+++ b/files/helpers/strings.py
@@ -1,11 +1,16 @@
 
+import typing
+
 # clean strings for searching
 def sql_ilike_clean(my_str):
 	return my_str.replace(r'\\', '').replace('_', r'\_').replace('%', '').strip()
 
-def bool_from_string(str_in: str) -> bool:
-	if str_in.lower() in ("yes", "true", "t", "1"):
+# this will also just return a bool verbatim
+def bool_from_string(input: typing.Union[str, bool]) -> bool:
+	if isinstance(input, bool):
+		return input
+	if input.lower() in ("yes", "true", "t", "on", "1"):
 		return True
-	if str_in.lower() in ("no", "false", "f", "0"):
+	if input.lower() in ("no", "false", "f", "off", "0"):
 		return False
 	raise ValueError()

--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -71,7 +71,8 @@ def leaderboard_thread():
 	db.close()
 	stdout.flush()
 
-gevent.spawn(leaderboard_thread())
+if app.config["ENABLE_SERVICES"]:
+	gevent.spawn(leaderboard_thread())
 
 @app.get("/@<username>/upvoters/<uid>/posts")
 @admin_level_required(3)

--- a/supervisord.conf.dev
+++ b/supervisord.conf.dev
@@ -5,7 +5,7 @@ logfile=/tmp/supervisord.log
 
 [program:service]
 directory=/service
-command=sh -c 'python3 -m flask db upgrade && WERKZEUG_DEBUG_PIN=off python3 -m flask --debug run --host=0.0.0.0 --port=80'
+command=sh -c 'python3 -m flask db upgrade && WERKZEUG_DEBUG_PIN=off ENABLE_SERVICES=true python3 -m flask --debug run --host=0.0.0.0 --port=80'
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/supervisord.conf.release
+++ b/supervisord.conf.release
@@ -5,7 +5,7 @@ logfile=/tmp/supervisord.log
 
 [program:service]
 directory=/service
-command=sh -c 'python3 -m flask db upgrade && gunicorn files.__main__:app -k gevent -w 1 --reload -b 0.0.0.0:80 --max-requests 1000 --max-requests-jitter 500'
+command=sh -c 'python3 -m flask db upgrade && ENABLE_SERVICES=true gunicorn files.__main__:app -k gevent -w 1 --reload -b 0.0.0.0:80 --max-requests 1000 --max-requests-jitter 500'
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
The problem was that the Leaderboard would query the user table, which was filled out based on the original .sql, and this would happen *before* the update process had a chance to run. This disables the leaderboard if we're running in a mode intended for operations and not for actual hosting.