### PR TITLE
Fix:  Docker overlay missing version

### DIFF
--- a/docker-compose-operation.yml
+++ b/docker-compose-operation.yml
@@ -1,3 +1,5 @@
+version: '2.3'
+
 services:
   files:
     container_name: "themotte"


### PR DESCRIPTION
Docker on Ubuntu checks versions between yml files, defaults to V1 if no version is found, and crashes if the version is different.