### PR TITLE
Replace sql_ilike_clean with func.lower for non-pattern uses; also fixes @-link bug

### DIFF
--- a/files/routes/front.py
+++ b/files/routes/front.py
@@ -1,5 +1,6 @@
 from files.helpers.wrappers import *
 from files.helpers.get import *
+from files.helpers.strings import sql_ilike_clean
 from files.__main__ import app, cache, limiter
 from files.classes.submission import Submission
 from files.helpers.contentsorting import apply_time_filter, sort_objects
@@ -269,7 +270,7 @@ def frontlist(v=None, sort='new', page=1, t="all", ids_only=True, ccmode="false"
 
 	if v and filter_words:
 		for word in filter_words:
-			word  = word.replace(r'\\', '').replace('_', r'\_').replace('%', r'\%').strip()
+			word  = sql_ilike_clean(word).strip()
 			posts=posts.filter(not_(Submission.title.ilike(f'%{word}%')))
 
 	if not (v and v.shadowbanned):

--- a/files/routes/login.py
+++ b/files/routes/login.py
@@ -2,7 +2,6 @@ from urllib.parse import urlencode
 from files.mail import *
 from files.__main__ import app, limiter
 from files.helpers.const import *
-from files.helpers.strings import sql_ilike_clean
 import requests
 
 @app.get("/login")
@@ -90,7 +89,7 @@ def login_post():
 	if username.startswith('@'): username = username[1:]
 
 	if "@" in username:
-		try: account = g.db.query(User).filter(User.email.ilike(sql_ilike_clean(username))).one_or_none()
+		try: account = g.db.query(User).filter(func.lower(User.email) == username.lower()).one_or_none()
 		except: return "Multiple users use this email!"
 	else: account = get_user(username, graceful=True)
 
@@ -189,8 +188,7 @@ def sign_up_get(v):
 	ref = request.values.get("ref")
 
 	if ref:
-		ref  = sql_ilike_clean(ref)
-		ref_user = g.db.query(User).filter(User.username.ilike(ref)).one_or_none()
+		ref_user = g.db.query(User).filter(func.lower(User.username) == ref.lower()).one_or_none()
 
 	else:
 		ref_user = None
@@ -386,13 +384,11 @@ def post_forgot():
 	if not email_regex.fullmatch(email):
 		return render_template("forgot_password.html", error="Invalid email.")
 
-
-	username  = sql_ilike_clean(username.lstrip('@'))
-	email  = sql_ilike_clean(email)
+	username  = username.lstrip('@')
 
 	user = g.db.query(User).filter(
-		User.username.ilike(username),
-		User.email.ilike(email)).one_or_none()
+		func.lower(User.username) == username.lower(),
+		func.lower(User.email) == email.lower()).one_or_none()
 
 	if user:
 		now = int(time.time())

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -2,10 +2,10 @@ import time
 import gevent
 from files.helpers.wrappers import *
 from files.helpers.sanitize import *
-from files.helpers.strings import sql_ilike_clean
 from files.helpers.alerts import *
 from files.helpers.contentsorting import sort_objects
 from files.helpers.const import *
+from files.helpers.strings import sql_ilike_clean
 from files.classes import *
 from flask import *
 from io import BytesIO
@@ -658,7 +658,7 @@ def api_is_repost():
 
 	if url.endswith('/'): url = url[:-1]
 
-	search_url = url.replace('%', '').replace(r'\\', '').replace('_', r'\_').strip()
+	search_url = sql_ilike_clean(url)
 	repost = g.db.query(Submission).filter(
 		Submission.url.ilike(search_url),
 		Submission.deleted_utc == 0,
@@ -735,13 +735,12 @@ def submit_post(v, sub=None):
 								query=urlencode(filtered, doseq=True),
 								fragment=parsed_url.fragment)
 		
-		url = urlunparse(new_url)
+		search_url = urlunparse(new_url)
 
-		if url.endswith('/'): url = url[:-1]
+		if search_url.endswith('/'): url = url[:-1]
 
-		search_url = sql_ilike_clean(url)
 		repost = g.db.query(Submission).filter(
-			Submission.url.ilike(search_url),
+			func.lower(Submission.url) == search_url.lower(),
 			Submission.deleted_utc == 0,
 			Submission.is_banned == False
 		).first()

--- a/files/routes/search.py
+++ b/files/routes/search.py
@@ -72,8 +72,7 @@ def searchposts(v):
 		else: posts = posts.filter(Submission.author_id == author.id)
 
 	if 'q' in criteria:
-		words=criteria['q'].split()
-		words = criteria['q'].replace(r'\\', '').replace('_', r'\_').replace('%', r'\%').strip().split()
+		words = sql_ilike_clean(criteria['q']).split()
 		words=[Submission.title.ilike('%'+x+'%') for x in words]
 		posts=posts.filter(*words)
 		
@@ -158,7 +157,7 @@ def searchcomments(v):
 		else: comments = comments.filter(Comment.author_id == author.id)
 
 	if 'q' in criteria:
-		words = criteria['q'].replace(r'\\', '').replace('_', r'\_').replace('%', r'\%').strip().split()
+		words = sql_ilike_clean(criteria['q']).split()
 
 		words = [Comment.body.ilike('%'+x+'%') for x in words]
 		comments = comments.filter(*words)

--- a/files/routes/settings.py
+++ b/files/routes/settings.py
@@ -626,12 +626,10 @@ def settings_name_change(v):
 						   v=v,
 						   error="This isn't a valid username.")
 
-	search_name = sql_ilike_clean(new_name)
-
-	x= g.db.query(User).filter(
+	x = g.db.query(User).filter(
 		or_(
-			User.username.ilike(search_name),
-			User.original_username.ilike(search_name)
+			func.lower(User.username) == new_name.lower(),
+			func.lower(User.original_username) == new_name.lower()
 			)
 		).one_or_none()
 


### PR DESCRIPTION
Within sqlalchemy, `query.filter()` using `ilike()` with patterned string will do a case insensitive pattern comparison with `_` matching any single char and `%` matching 0 or more chars.

As it was, if you call `sql_ilike_clean("under_score")` it returns `"under\\_score"` instead of `"under\_score"`.  Sqlalchemy happily passes that string into the filter and then fails to find matches, as `"under_score" != "under\\_score"`, even when factoring in the pattern matching.

The issue at the heart of #398 is that python doesn't seem to work properly with raw strings and escape chars, leading to un-escaped `_`s in the pattern strings and breaking the filter.

Replacing this use case with explicit calls to `func.lower()` and using `str.lower` in cases where the full pattern matching isn't necessary fixes the bug and should likely prevent other similar bugs from silently occuring.

Further work is necessary to validate that the remaining uses of `sql_ilike_clean()` are not introducing other similar bugs where they're being used for more appropriate pattern matching.