### PR TITLE
fix: correct return type for volunteer duties

### DIFF
--- a/files/routes/volunteer_janitor.py
+++ b/files/routes/volunteer_janitor.py
@@ -1,4 +1,5 @@
 
+from typing import Optional
 from files.__main__ import app
 from files.classes.comment import Comment
 from files.classes.flags import CommentFlag
@@ -33,7 +34,7 @@ class VolunteerDutyJanitor(VolunteerDuty):
         return g.db.query(Comment).where(Comment.id.in_(self.choices))
 
 
-def get_duty(u: User) -> VolunteerDutyJanitor:
+def get_duty(u: User) -> Optional[VolunteerDutyJanitor]:
     if not app.config['VOLUNTEER_JANITOR_ENABLE']:
         return None
 


### PR DESCRIPTION
make sure return type is correct (i.e. wrapped in `Optional`) so callees don't get an unexpected `None`