### PR TITLE
Randomize order of sidebar recommendation lists, cleanup

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -5031,6 +5031,9 @@ a.emojitab {
 	padding: 2px 5px;
 	font-weight: 700;
 }
+.sidebar {
+	max-width: 300px;
+}
 li > .sidebar {
 	display: block !important;
 	max-width: 100% !important;

--- a/files/helpers/jinja2.py
+++ b/files/helpers/jinja2.py
@@ -1,9 +1,25 @@
+from os import listdir, environ
+import random
+import time
+
+from jinja2 import pass_context
+
 from files.__main__ import app
 from .get import *
-from os import listdir, environ
 from .const import * 
-import time
 from files.helpers.assetcache import assetcache_path
+
+
+@app.template_filter("shuffle")
+@pass_context
+def template_shuffle(ctx, l: list) -> list:
+	# Uses @pass_context while ignoring `ctx` to prevent Jinja from
+	# caching the result of the filter
+
+	# stdlib recommended idiom for shuffling out-of-place
+	# as opposed to random.shuffle for in-place shuffling
+	return random.sample(l, k=len(l))
+
 
 @app.template_filter("post_embed")
 def post_embed(id, v):
@@ -43,9 +59,11 @@ def timestamp(timestamp):
 		years = int(months / 12)
 		return f"{years}yr ago"
 
+
 @app.template_filter("asset")
 def template_asset(asset_path):
 	return assetcache_path(asset_path)
+
 
 @app.context_processor
 def inject_constants():
@@ -67,6 +85,7 @@ def inject_constants():
 		"THEMES":THEMES,
 		"PERMS":PERMS,
 	}
+
 
 def template_function(func):
 	assert(func.__name__ not in app.jinja_env.globals)

--- a/files/templates/sidebar_TheMotte.html
+++ b/files/templates/sidebar_TheMotte.html
@@ -1,12 +1,8 @@
-<div class="col sidebar text-left d-none d-lg-block pt-4 pb-5 bg-white" style="max-width:300px">
+<div class="col sidebar text-left d-none d-lg-block pt-4 pb-5 bg-white">
 
 	<div class="d-none d-lg-block">
 		{% include "nav_secondary.html" %}
 	</div>
-
-	{% if sub %}
-		{% set image=sub.sidebar_url %}
-	{% endif %}
 
 	{% if sub %}
 		{% if sub.sidebar_html %}
@@ -134,20 +130,4 @@
 			</ul>
 		</div>
 	{% endif %}
-<pre>
-
-
-
-
-
-
-
-
-
-
-			
-
-
-		
-</pre>
 </div>

--- a/files/templates/sidebar_TheMotte.html
+++ b/files/templates/sidebar_TheMotte.html
@@ -116,17 +116,21 @@
 
 			<h4>Recommended Posts And Communities</h4>
 			<ul>
-				<li><a href="https://www.vault.themotte.org/">The Vault</a></li>
-				<li><a href="https://www.lesswrong.com/">Lesswrong</a></li>
-				<li><a href="https://astralcodexten.substack.com/">Astral Codex Ten</a></li>
-				<li><a href="https://www.slatestarcodex.com/">Slate Star Codex</a></li>
-				<li><a href="https://www.reddit.com/r/FeMRADebates/">FeMRA Debates</a></li>
+				{{[
+				'<li><a href="https://www.vault.themotte.org/">The Vault</a></li>',
+				'<li><a href="https://www.lesswrong.com/">Lesswrong</a></li>',
+				'<li><a href="https://astralcodexten.substack.com/">Astral Codex Ten</a></li>',
+				'<li><a href="https://www.slatestarcodex.com/">Slate Star Codex</a></li>',
+				'<li><a href="https://www.reddit.com/r/FeMRADebates/">FeMRA Debates</a></li>',
+				]|shuffle|join('\n')|safe}}
 			</ul>
 
 			<h4>Recommended Realtime Chats</h4>
 			<ul>
-				<li><a href="https://discord.gg/Hkyq5eN">Astral Codex Ten Discord</a></li>
-				<li><a href="https://t.me/quokkas_den">Quokka's Den Telegram</a></li>
+				{{[
+				'<li><a href="https://discord.gg/Hkyq5eN">Astral Codex Ten Discord</a></li>',
+				'<li><a href="https://t.me/quokkas_den">Quokka\'s Den Telegram</a></li>',
+				]|shuffle|join('\n')|safe}}
 			</ul>
 		</div>
 	{% endif %}


### PR DESCRIPTION
Fixes #483. Implement a Jinja template filter to shuffle a sequence (which surprisingly doesn't already exist) and shuffle the relevant lists in the sidebar.

---

Cleanup sidebar sizing style kludges:
    
    The 15-line <pre> block at the bottom of the sidebar was a fix for
    mobile hamburger menu behavior on upstream, where the long mobile
    sidebar would be covered by the bottom navigation drawer.
    
    In-place replacement would be `margin-bottom: 15em`, but it's not
    actually necessary for the sidebar as used on TheMotte, and it adds
    an unsightly block of whitespace to the bottom of the homepage.
    
    Also the `style` attribute width was related to `GET /sidebar`
    behavior (sidebar.html), which is unused on TheMotte, having been
    replaced in the signup template with a link to `/rules`.