### PR TITLE
Fix comment eager loading

### DIFF
--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -238,6 +238,7 @@ def post_id(pid, anything=None, v=None, sub=None):
 	g.db.expire_on_commit = False
 	g.db.add(post)
 	g.db.commit()
+	g.db.expire_on_commit = True
 
 	if request.headers.get("Authorization"): return post.json
 	else:

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -235,6 +235,7 @@ def post_id(pid, anything=None, v=None, sub=None):
 	post.replies = get_comment_trees_eager(top_comment_ids, sort, v)
 
 	post.views += 1
+	g.db.expire_on_commit = False
 	g.db.add(post)
 	g.db.commit()
 


### PR DESCRIPTION
Following #485, we began investigating post/comment rendering bottlenecks. The most immediate issue is the eager comment loading (merged in 23a8fb966385) did not seem fully operative: query logs showed comments and associated FKs were being lazy loaded again (linear query quantity in number of rendered comments). In fact, CPU load seemed even worse than previous lazy loading.

Bisect revealed first bad commit: fb77cbcc2b5
which fixed post view counters by committing the SQLAlchemy session instead of flushing, following upstream's fix. However, committing a session has the unfortunate side effect of dumping cached session objects, such as the previously loaded comment objects and their relationships, causing fallback to the old lazy behavior.

We fix this here by moving the commit above all the expensive loading, as confirmed by easy_profile. This is sub-optimal: ideally we could find root cause on why flushing was insufficient for post views. However, there is no non-error path to abort after this point in the route handler, and it Should™ be fine.

Hopefully this will simultaneously resolve the elevated DB CPU load observed in production and speed up page rendering again.