### PR TITLE
Remove legacy comment pagination logic

### DIFF
--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -206,18 +206,11 @@ def post_id(pid, anything=None, v=None, sub=None):
 	if post.comment_count > limit and not request.headers.get("Authorization") and not request.values.get("all"):
 		comments2 = []
 		count = 0
-		if post.created_utc > 1638672040:
-			for comment in comments:
-				comments2.append(comment)
-				ids.add(comment.id)
-				count += g.db.query(Comment.id).filter_by(parent_submission=post.id, top_comment_id=comment.id).count() + 1
-				if count > limit: break
-		else:
-			for comment in comments:
-				comments2.append(comment)
-				ids.add(comment.id)
-				count += g.db.query(Comment.id).filter_by(parent_submission=post.id, parent_comment_id=comment.id).count() + 1
-				if count > limit: break
+		for comment in comments:
+			comments2.append(comment)
+			ids.add(comment.id)
+			count += g.db.query(Comment.id).filter_by(parent_submission=post.id, top_comment_id=comment.id).count() + 1
+			if count > limit: break
 
 		if len(comments) == len(comments2): offset = 0
 		else: offset = 1
@@ -324,18 +317,11 @@ def viewmore(v, pid, sort, offset):
 	comments2 = []
 	count = 0
 
-	if post.created_utc > 1638672040:
-		for comment in comments:
-			comments2.append(comment)
-			ids.add(comment.id)
-			count += g.db.query(Comment.id).filter_by(parent_submission=post.id, top_comment_id=comment.id).count() + 1
-			if count > limit: break
-	else:
-		for comment in comments:
-			comments2.append(comment)
-			ids.add(comment.id)
-			count += g.db.query(Comment.id).filter_by(parent_submission=post.id, parent_comment_id=comment.id).count() + 1
-			if count > limit: break
+	for comment in comments:
+		comments2.append(comment)
+		ids.add(comment.id)
+		count += g.db.query(Comment.id).filter_by(parent_submission=post.id, top_comment_id=comment.id).count() + 1
+		if count > limit: break
 	
 	if len(comments) == len(comments2): offset = 0
 	else: offset += 1


### PR DESCRIPTION
The comments schema, prior to December 2021, used parent_comment_id instead of also storing top_comment_id. Comment pagination is based now on top_comment_id. However, upstream never migrated their old comments to populate tc_id, and thus retained two copies of pagination logic, each using different limits to try to emulate similar behavior.

TheMotte foremost has no posts created prior to December 2021 (so these branches never activated) and also has tc_id on all comments.

The dual limit pagination approach was already removed (there is only one limit for paginating comments). This completes the removal of this logic, since these are purely dead codepaths which have previously caused confusion to contributors.