### PR TITLE
add SQLALCHEMY_WARN_20 env var to env

### DIFF
--- a/env
+++ b/env
@@ -31,6 +31,7 @@ MENTION_LIMIT=100
 MULTIMEDIA_EMBEDDING_ENABLED=False
 RESULTS_PER_PAGE_COMMENTS=200
 SCORE_HIDING_TIME_HOURS=24
+SQLALCHEMY_WARN_20=0
 
 # Profiling system; uncomment to enable
 # Stores and exposes sensitive data!


### PR DESCRIPTION
SQLA uses an environment variable to enable whether showing warnings or not. unfortunately there doesn't seem to be a way that i can tell to get whether debug mode is enabled before SQLAlchemy is imported, and anything after importing SQLAlchemy is too late

this is for #487 