### PR TITLE
Future-proof for Flask-Limiter update

### DIFF
--- a/files/__main__.py
+++ b/files/__main__.py
@@ -141,8 +141,8 @@ app.config['RATE_LIMITER_ENABLED'] = not bool_from_string(environ.get('DBG_LIMIT
 if not app.config['RATE_LIMITER_ENABLED']:
 	print("Rate limiter disabled in debug mode!")
 limiter = Limiter(
-	app,
 	key_func=get_remote_addr,
+	app=app,
 	default_limits=["3/second;30/minute;200/hour;1000/day"],
 	application_limits=["10/second;200/minute;5000/hour;10000/day"],
 	storage_uri=environ.get("REDIS_URL", "redis://localhost"),


### PR DESCRIPTION
We currently use Flask-Limiter 2.7.0. Upgrading to 3.1.0 breaks because of a breaking change to keyword order. Yes, seriously:

https://flask-limiter.readthedocs.io/en/stable/changelog.html#v3-0-0

Not updating the lockfile here, pending @ZorbaTHut testing some infra updates; however, this is necessary to be able to do so, and it still works in 2.7.0.