### PR TITLE
errors: fix missing error handler for 409

### DIFF
--- a/files/routes/errors.py
+++ b/files/routes/errors.py
@@ -1,15 +1,18 @@
-from files.helpers.wrappers import *
-from flask import request, session
-from urllib.parse import quote, urlencode
 import time
-from files.__main__ import app
 from http.client import responses
+from urllib.parse import quote, urlencode
+
+from flask import redirect, render_template, request, session
+
+from files.helpers.const import ERROR_MESSAGES, SITE_FULL, WERKZEUG_ERROR_DESCRIPTIONS
+from files.__main__ import app
 
 @app.errorhandler(400)
 @app.errorhandler(401)
 @app.errorhandler(403)
 @app.errorhandler(404)
 @app.errorhandler(405)
+@app.errorhandler(409)
 @app.errorhandler(413)
 @app.errorhandler(422)
 @app.errorhandler(429)


### PR DESCRIPTION
fixes a missing error handler for the 409 status code (used for duplicate comments, etc)