### PR TITLE
fix missing import used by error handler

### DIFF
--- a/files/routes/errors.py
+++ b/files/routes/errors.py
@@ -2,7 +2,7 @@ import time
 from http.client import responses
 from urllib.parse import quote, urlencode
 
-from flask import redirect, render_template, request, session
+from flask import g, redirect, render_template, request, session
 
 from files.helpers.const import ERROR_MESSAGES, SITE_FULL, WERKZEUG_ERROR_DESCRIPTIONS
 from files.__main__ import app


### PR DESCRIPTION
500s cause an exception with a NameError otherwise

traceback:
```
site_1      | During handling of the above exception, another exception occurred:
site_1      |
site_1      | Traceback (most recent call last):
site_1      |   File "/usr/local/lib/python3.10/site-packages/gunicorn/workers/base_async.py", line 55, in handle
site_1      |     self.handle_request(listener_name, req, client, addr)
site_1      |   File "/usr/local/lib/python3.10/site-packages/gunicorn/workers/ggevent.py", line 127, in handle_request
site_1      |     super().handle_request(listener_name, req, sock, addr)
site_1      |   File "/usr/local/lib/python3.10/site-packages/gunicorn/workers/base_async.py", line 108, in handle_request
site_1      |     respiter = self.wsgi(environ, resp.start_response)
site_1      |   File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 2548, in __call__
site_1      |     return self.wsgi_app(environ, start_response)
site_1      |   File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 2528, in wsgi_app
site_1      |     response = self.handle_exception(e)
site_1      |   File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1724, in handle_exception
site_1      |     server_error = self.ensure_sync(handler)(server_error)
site_1      |   File "/service/files/routes/errors.py", line 39, in error_500
site_1      |     if getattr(g, 'db', None):
site_1      | NameError: name 'g' is not defined
```