### PR TITLE
SQLA2 migration: fix `MovedIn20Warning`

### DIFF
--- a/files/__main__.py
+++ b/files/__main__.py
@@ -11,7 +11,6 @@ from flask_limiter import Limiter
 from flask_compress import Compress
 from flask_mail import Mail
 import flask_profiler
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy import *
 import gevent
@@ -149,8 +148,6 @@ limiter = Limiter(
 	auto_check=False,
 	enabled=app.config['RATE_LIMITER_ENABLED'],
 )
-
-Base = declarative_base()
 
 engine = create_engine(app.config['DATABASE_URL'])
 

--- a/files/classes/__init__.py
+++ b/files/classes/__init__.py
@@ -92,4 +92,5 @@ from files.helpers.security import *
 
 # Then the specific stuff we don't want stomped on
 from files.helpers.lazy import lazy
-from files.__main__ import Base, app, cache
+from files.classes.base import Base
+from files.__main__ import app, cache

--- a/files/classes/alts.py
+++ b/files/classes/alts.py
@@ -1,5 +1,5 @@
 from sqlalchemy import *
-from files.__main__ import Base
+from files.classes.base import Base
 
 
 class Alt(Base):

--- a/files/classes/award.py
+++ b/files/classes/award.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 from os import environ
 from files.helpers.lazy import lazy
 from files.helpers.const import *

--- a/files/classes/badges.py
+++ b/files/classes/badges.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base, app
+from files.classes.base import Base
 from os import environ
 from files.helpers.lazy import lazy
 from files.helpers.const import *

--- a/files/classes/base.py
+++ b/files/classes/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/files/classes/clients.py
+++ b/files/classes/clients.py
@@ -3,7 +3,7 @@ from sqlalchemy import *
 from sqlalchemy.orm import relationship
 from .submission import Submission
 from .comment import Comment
-from files.__main__ import Base
+from files.classes.base import Base
 from files.helpers.lazy import lazy
 from files.helpers.const import *
 import time

--- a/files/classes/comment.py
+++ b/files/classes/comment.py
@@ -5,7 +5,8 @@ from urllib.parse import urlencode, urlparse, parse_qs
 from flask import *
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base, app
+from files.classes.base import Base
+from files.__main__ import app
 from files.classes.votes import CommentVote
 from files.helpers.const import *
 from files.helpers.lazy import lazy

--- a/files/classes/domains.py
+++ b/files/classes/domains.py
@@ -1,5 +1,5 @@
 from sqlalchemy import *
-from files.__main__ import Base
+from files.classes.base import Base
 
 class BannedDomain(Base):
 

--- a/files/classes/exiles.py
+++ b/files/classes/exiles.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 
 class Exile(Base):
 

--- a/files/classes/flags.py
+++ b/files/classes/flags.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 from files.helpers.lazy import lazy
 from files.helpers.const import *
 import time

--- a/files/classes/follows.py
+++ b/files/classes/follows.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 import time
 
 class Follow(Base):

--- a/files/classes/marsey.py
+++ b/files/classes/marsey.py
@@ -1,5 +1,5 @@
 from sqlalchemy import *
-from files.__main__ import Base
+from files.classes.base import Base
 
 class Marsey(Base):
 	__tablename__ = "marseys"

--- a/files/classes/mod.py
+++ b/files/classes/mod.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 from files.helpers.lazy import *
 import time
 

--- a/files/classes/mod_logs.py
+++ b/files/classes/mod_logs.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 import time
 from files.helpers.lazy import lazy
 from os import environ

--- a/files/classes/notifications.py
+++ b/files/classes/notifications.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 import time
 
 class Notification(Base):

--- a/files/classes/saves.py
+++ b/files/classes/saves.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 
 
 class SaveRelationship(Base):

--- a/files/classes/sub.py
+++ b/files/classes/sub.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 from files.helpers.lazy import lazy
 from os import environ
 from .sub_block import *

--- a/files/classes/sub_block.py
+++ b/files/classes/sub_block.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 
 class SubBlock(Base):
 

--- a/files/classes/submission.py
+++ b/files/classes/submission.py
@@ -6,7 +6,8 @@ from urllib.parse import urlparse
 from flask import render_template
 from sqlalchemy import *
 from sqlalchemy.orm import relationship, deferred
-from files.__main__ import Base, app
+from files.classes.base import Base
+from files.__main__ import app
 from files.helpers.const import *
 from files.helpers.lazy import lazy
 from files.helpers.assetcache import assetcache_path

--- a/files/classes/subscriptions.py
+++ b/files/classes/subscriptions.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 
 class Subscription(Base):
 	__tablename__ = "subscriptions"

--- a/files/classes/user.py
+++ b/files/classes/user.py
@@ -17,7 +17,7 @@ from .mod_logs import *
 from .mod import *
 from .exiles import *
 from .sub_block import *
-from files.__main__ import app, Base, cache
+from files.__main__ import app, cache
 from files.helpers.security import *
 from files.helpers.assetcache import assetcache_path
 from files.helpers.contentsorting import apply_time_filter, sort_objects

--- a/files/classes/user.py
+++ b/files/classes/user.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import deferred, aliased
 from secrets import token_hex
 import pyotp
+from files.classes.base import Base
 from files.helpers.media import *
 from files.helpers.const import *
 from .alts import Alt

--- a/files/classes/userblock.py
+++ b/files/classes/userblock.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 
 class UserBlock(Base):
 

--- a/files/classes/usernotes.py
+++ b/files/classes/usernotes.py
@@ -2,7 +2,7 @@ import time
 from flask import *
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 from files.helpers.const import *
 from enum import Enum
 from sqlalchemy import Enum as EnumType

--- a/files/classes/views.py
+++ b/files/classes/views.py
@@ -1,6 +1,6 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 from files.helpers.lazy import *
 import time
 

--- a/files/classes/volunteer_janitor.py
+++ b/files/classes/volunteer_janitor.py
@@ -1,6 +1,6 @@
 
 import enum
-from files.__main__ import Base
+from files.classes.base import Base
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
 

--- a/files/classes/votes.py
+++ b/files/classes/votes.py
@@ -1,7 +1,7 @@
 from flask import *
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
-from files.__main__ import Base
+from files.classes.base import Base
 from files.helpers.lazy import lazy
 import time
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('alembic.env')
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-from files.__main__ import Base
+from files.classes.base import Base
 target_metadata = Base.metadata
 
 config.set_main_option(

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ As an example, let's say we want to add a column `is_flagged` to the `comments` 
 
 1. Update the `Comment` model in `files/classes/comment.py`
 ```python
-	from files.__main__ import Base
+	from files.classes.base import Base
 	class Comment(Base):
 		__tablename__ = "comments"
 		id = Column(Integer, primary_key=True)


### PR DESCRIPTION
shouldn't actually cause any issues currently since SQLAlchemy is (to my annoyance) import *ed everywhere but.

ref #487 