### PR TITLE
Fix leaderboard 500 on production (NotImplementedError)

### DIFF
--- a/files/classes/leaderboard.py
+++ b/files/classes/leaderboard.py
@@ -132,7 +132,7 @@ class BadgeMarseyLeaderboard(_CountedAndRankedLeaderboard):
 
 	@property
 	def value_func(self) -> Callable[[User], int]:
-		return lambda u:self._all_users[u]
+		return lambda u: self._all_users[u]
 	
 class UserBlockLeaderboard(_CountedAndRankedLeaderboard):
 	def __init__(self, v:User, meta:LeaderboardMeta, db:scoped_session, column:Column):
@@ -167,6 +167,10 @@ class UserBlockLeaderboard(_CountedAndRankedLeaderboard):
 	@property
 	def v_value(self) -> int:
 		return self._v_value
+
+	@property
+	def value_func(self) -> Callable[[User], int]:
+		return lambda u: self._all_users[u]
 
 class RawSqlLeaderboard(Leaderboard):
 	def __init__(self, meta:LeaderboardMeta, db:scoped_session, query:str) -> None: # should be LiteralString on py3.11+

--- a/files/helpers/services.py
+++ b/files/helpers/services.py
@@ -44,6 +44,9 @@ def pusher_thread2(interests, notifbody, username):
 _lb_received_downvotes_meta = LeaderboardMeta("Downvotes", "received downvotes", "received-downvotes", "downvotes", "downvoted")
 _lb_given_upvotes_meta = LeaderboardMeta("Upvotes", "given upvotes", "given-upvotes", "upvotes", "upvoting")
 
+lb_downvotes_received: ReceivedDownvotesLeaderboard | None = None
+lb_upvotes_given: GivenUpvotesLeaderboard | None = None
+
 def leaderboard_thread():
 	global lb_downvotes_received, lb_upvotes_given
 

--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -376,7 +376,9 @@ def leaderboard(v:User):
 
 	# note: lb_downvotes_received and lb_upvotes_given are global variables
 	# that are populated by leaderboard_thread() in files.helpers.services
-	leaderboards = [coins, coins_spent, truescore, subscribers, posts, comments, received_awards, badges, blocks, lb_downvotes_received, lb_upvotes_given]
+	leaderboards = [coins, coins_spent, truescore, subscribers, posts, comments, received_awards, badges, blocks]
+	if lb_downvotes_received is not None and lb_upvotes_given is not None:
+		leaderboards.extend([lb_downvotes_received, lb_upvotes_given])
 
 	return render_template("leaderboard.html", v=v, leaderboards=leaderboards)
 


### PR DESCRIPTION
UserBlockLeaderboard did not, in fact, implement `value_func`. Nor did its superclass. The bug was replicated by having at least one UserBlock in the test data. We borrow the boilerplate `value_func` from `BadgeMarseyLeaderboard`, which resolves the error.

Also, in the process of troubleshooting, fixed a secondary bug where `ENABLE_SERVICES=false` wouldn't remove the non-existent leaderboards from the list to be rendered.