### PR TITLE
hotfix: comment nesting in template from #535

### DIFF
--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -52,9 +52,9 @@
 			</div>
 		{% endif %}
 	{% endif %}
+		</div>
 </div>
 {% endif %}
-</div>
 
 {% else %}
 


### PR DESCRIPTION
In some cases, #535 caused comment display to wildly break visible page formatting. The sidebar often moved to bottom of page, and some comments would display in a second column alongside the main one.

Root cause was a closing `</div>` left outside of a conditional which was included in rendered markup even when:
 1) A comment is invisible for the current browsing user v, e.g. filtered or removed.
 2) The subtree rooted at said comment is to be hidden based on the display logic added in #535.
Which left a stray `</div>` with no opening tag where those comments should've gone.

Most of the testing appears to have been done on reply chains of comments, which behave correctly. It is specifically the zero children (or otherwise not even showing a "Removed" message in the page) which causes the bug.