### PR TITLE
perms: consistently use >= for admin level checks

### DIFF
--- a/files/classes/comment.py
+++ b/files/classes/comment.py
@@ -115,7 +115,7 @@ class Comment(CreatedBase):
 	@lazy
 	def flags(self, v):
 		flags = self.reports
-		if not (v and (v.shadowbanned or v.admin_level > 2)):
+		if not (v and (v.shadowbanned or v.admin_level >= 3)):
 			for flag in flags:
 				if flag.user.shadowbanned:
 					flags.remove(flag)

--- a/files/classes/submission.py
+++ b/files/classes/submission.py
@@ -142,7 +142,7 @@ class Submission(CreatedBase):
 	@lazy
 	def flags(self, v):
 		flags = g.db.query(Flag).filter_by(post_id=self.id).order_by(Flag.created_utc).all()
-		if not (v and (v.shadowbanned or v.admin_level > 2)):
+		if not (v and (v.shadowbanned or v.admin_level >= 3)):
 			for flag in flags:
 				if flag.user.shadowbanned:
 					flags.remove(flag)

--- a/files/classes/user.py
+++ b/files/classes/user.py
@@ -425,8 +425,8 @@ class User(CreatedBase):
 				'profile_url': self.profile_url,
 				'bannerurl': self.banner_url,
 				'bio_html': self.bio_html_eager,
-				'post_count': 0 if self.shadowbanned and not (v and (v.shadowbanned or v.admin_level > 1)) else self.post_count,
-				'comment_count': 0 if self.shadowbanned and not (v and (v.shadowbanned or v.admin_level > 1)) else self.comment_count,
+				'post_count': 0 if self.shadowbanned and not (v and (v.shadowbanned or v.admin_level >= 2)) else self.post_count,
+				'comment_count': 0 if self.shadowbanned and not (v and (v.shadowbanned or v.admin_level >= 2)) else self.comment_count,
 				'badges': [x.path for x in self.badges],
 				}
 

--- a/files/helpers/comments.py
+++ b/files/helpers/comments.py
@@ -223,7 +223,7 @@ def comment_on_unpublish(comment:Comment):
 
 
 def comment_filter_moderated(q: Query, v: Optional[User]) -> Query:
-	if not (v and v.shadowbanned) and not (v and v.admin_level > 2):
+	if not (v and v.shadowbanned) and not (v and v.admin_level >= 3):
 		q = q.join(User, User.id == Comment.author_id) \
 		     .filter(User.shadowbanned == None)
 	if not v or v.admin_level < 2:

--- a/files/helpers/get.py
+++ b/files/helpers/get.py
@@ -262,7 +262,7 @@ def get_comments(
 			blocked.c.target_id,
 		).filter(Comment.id.in_(cids))
  
-		if not (v and (v.shadowbanned or v.admin_level > 1)):
+		if not (v and (v.shadowbanned or v.admin_level >= 2)):
 			comments = comments.join(User, User.id == Comment.author_id) \
 				.filter(User.shadowbanned == None)
 

--- a/files/helpers/listing.py
+++ b/files/helpers/listing.py
@@ -101,11 +101,11 @@ def frontlist(v=None, sort='new', page=1, t="all", ids_only=True, ccmode="false"
 
 @cache.memoize(timeout=USERPAGELISTING_TIMEOUT_SECS)
 def userpagelisting(u:User, v=None, page=1, sort="new", t="all"):
-	if u.shadowbanned and not (v and (v.admin_level > 1 or v.id == u.id)): return []
+	if u.shadowbanned and not (v and (v.admin_level >= 2 or v.id == u.id)): return []
 
 	posts = g.db.query(Submission.id).filter_by(author_id=u.id, is_pinned=False)
 
-	if not (v and (v.admin_level > 1 or v.id == u.id)):
+	if not (v and (v.admin_level >= 2 or v.id == u.id)):
 		posts = posts.filter_by(deleted_utc=0, is_banned=False, private=False, ghost=False)
 
 	posts = apply_time_filter(posts, t, Submission)

--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -232,7 +232,7 @@ def sanitize(sanitized, alert=False, comment=False, edit=False):
 			if not u: continue
 			m = [ m for m in matches if u.username == m.group(2) or u.original_username == m.group(2) ]
 			for i in m:
-				if not (g.v and g.v.any_block_exists(u)) or g.v.admin_level > 1:
+				if not (g.v and g.v.any_block_exists(u)) or g.v.admin_level >= 2:
 					sanitized = sanitized.replace(i.group(0), f'''{i.group(1)}<a href="/id/{u.id}"><img loading="lazy" src="/pp/{u.id}">@{u.username}</a>''', 1)
 
 	soup = BeautifulSoup(sanitized, 'lxml')

--- a/files/routes/admin/admin.py
+++ b/files/routes/admin/admin.py
@@ -222,7 +222,7 @@ def club_ban(v, username):
 @limiter.exempt
 @auth_required
 def shadowbanned(v):
-	if not (v and v.admin_level > 1): abort(404)
+	if not (v and v.admin_level >= 2): abort(404)
 	users = [x for x in g.db.query(User).filter(User.shadowbanned != None).order_by(User.shadowbanned).all()]
 	return render_template("shadowbanned.html", v=v, users=users)
 
@@ -1189,7 +1189,7 @@ def sticky_post(post_id, v):
 	if post and not post.stickied:
 		pins = g.db.query(Submission.id).filter(Submission.stickied != None, Submission.is_banned == False).count()
 		if pins > 2:
-			if v.admin_level > 1:
+			if v.admin_level >= 2:
 				post.stickied = v.username
 				post.stickied_utc = int(time.time()) + 3600
 			else: abort(403, "Can't exceed 3 pinned posts limit!")

--- a/files/routes/chat.py
+++ b/files/routes/chat.py
@@ -70,7 +70,7 @@ def speak(data, v):
 
 	total += 1
 
-	if v.admin_level > 1:
+	if v.admin_level >= 2:
 		text = text.lower()
 		for i in mute_regex.finditer(text):
 			username = i.group(1)

--- a/files/routes/comments.py
+++ b/files/routes/comments.py
@@ -23,9 +23,9 @@ def post_pid_comment_cid(cid, pid=None, anything=None, v=None):
 
 	if comment.post and comment.post.club and not (v and (v.paid_dues or v.id in [comment.author_id, comment.post.author_id])): abort(403)
 
-	if comment.post and comment.post.private and not (v and (v.admin_level > 1 or v.id == comment.post.author.id)): abort(403)
+	if comment.post and comment.post.private and not (v and (v.admin_level >= 2 or v.id == comment.post.author.id)): abort(403)
 
-	if not comment.parent_submission and not (v and (comment.author.id == v.id or comment.sentto == v.id)) and not (v and v.admin_level > 1) : abort(403)
+	if not comment.parent_submission and not (v and (comment.author.id == v.id or comment.sentto == v.id)) and not (v and v.admin_level >= 2) : abort(403)
 	
 	if not pid:
 		if comment.parent_submission: pid = comment.parent_submission
@@ -65,7 +65,7 @@ def post_pid_comment_cid(cid, pid=None, anything=None, v=None):
 			blocked.c.target_id,
 		)
 
-		if not (v and v.shadowbanned) and not (v and v.admin_level > 2):
+		if not (v and v.shadowbanned) and not (v and v.admin_level >= 3):
 			comments = comments.join(User, User.id == Comment.author_id).filter(User.shadowbanned == None)
 		 
 		comments=comments.filter(
@@ -96,7 +96,7 @@ def post_pid_comment_cid(cid, pid=None, anything=None, v=None):
 			
 	if request.headers.get("Authorization"): return top_comment.json
 	else: 
-		if post.is_banned and not (v and (v.admin_level > 1 or post.author_id == v.id)): template = "submission_banned.html"
+		if post.is_banned and not (v and (v.admin_level >= 2 or post.author_id == v.id)): template = "submission_banned.html"
 		else: template = "submission.html"
 		return render_template(template, v=v, p=post, sort=sort, comment_info=comment_info, render_replies=True)
 

--- a/files/routes/front.py
+++ b/files/routes/front.py
@@ -49,12 +49,12 @@ def notifications(v):
 	modmail = request.values.get('modmail')
 	posts = request.values.get('posts')
 	reddit = request.values.get('reddit')
-	if modmail and v.admin_level > 1:
+	if modmail and v.admin_level >= 2:
 		comments = g.db.query(Comment).filter(Comment.sentto == MODMAIL_ID).order_by(Comment.id.desc()).offset(25*(page-1)).limit(26).all()
 		next_exists = (len(comments) > 25)
 		listing = comments[:25]
 	elif messages:
-		if v and (v.shadowbanned or v.admin_level > 2):
+		if v and (v.shadowbanned or v.admin_level >= 3):
 			comments = g.db.query(Comment).filter(Comment.sentto != None, or_(Comment.author_id==v.id, Comment.sentto==v.id), Comment.parent_submission == None, Comment.level == 1).order_by(Comment.id.desc()).offset(25*(page-1)).limit(26).all()
 		else:
 			comments = g.db.query(Comment).join(User, User.id == Comment.author_id).filter(User.shadowbanned == None, Comment.sentto != None, or_(Comment.author_id==v.id, Comment.sentto==v.id), Comment.parent_submission == None, Comment.level == 1).order_by(Comment.id.desc()).offset(25*(page-1)).limit(26).all()
@@ -106,7 +106,7 @@ def notifications(v):
 			Comment.body_html.notlike('%<p>New site mention: <a href="https://old.reddit.com/r/%')
 		).order_by(Notification.created_utc.desc())
 
-		if not (v and (v.shadowbanned or v.admin_level > 2)):
+		if not (v and (v.shadowbanned or v.admin_level >= 3)):
 			comments = comments.join(User, User.id == Comment.author_id).filter(User.shadowbanned == None)
 
 		comments = comments.offset(25 * (page - 1)).limit(26).all()

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -118,7 +118,7 @@ def post_id(pid, anything=None, v=None):
 
 	if request.headers.get("Authorization"): return post.json
 	else:
-		if post.is_banned and not (v and (v.admin_level > 1 or post.author_id == v.id)): template = "submission_banned.html"
+		if post.is_banned and not (v and (v.admin_level >= 2 or post.author_id == v.id)): template = "submission_banned.html"
 		else: template = "submission.html"
 		return render_template(template, v=v, p=post, ids=list(ids), sort=sort, render_replies=True, offset=offset)
 
@@ -636,7 +636,7 @@ def undelete_post_pid(pid, v):
 @auth_required
 def toggle_comment_nsfw(cid, v):
 	comment = g.db.query(Comment).filter_by(id=cid).one_or_none()
-	if comment.author_id != v.id and not v.admin_level > 1: abort(403)
+	if comment.author_id != v.id and not v.admin_level >= 2: abort(403)
 	comment.over_18 = not comment.over_18
 	g.db.add(comment)
 
@@ -650,7 +650,7 @@ def toggle_comment_nsfw(cid, v):
 def toggle_post_nsfw(pid, v):
 	post = get_post(pid)
 
-	if post.author_id != v.id and not v.admin_level > 1:
+	if post.author_id != v.id and not v.admin_level >= 2:
 		abort(403)
 
 	post.over_18 = not post.over_18

--- a/files/routes/reporting.py
+++ b/files/routes/reporting.py
@@ -14,7 +14,7 @@ def api_flag_post(pid, v):
 	reason = request.values.get("reason", "").strip()[:100]
 	reason = filter_emojis_only(reason)
 
-	if reason.startswith('!') and v.admin_level > 1:
+	if reason.startswith('!') and v.admin_level >= 2:
 		post.flair = reason[1:]
 		g.db.add(post)
 		ma=ModAction(

--- a/files/routes/static.py
+++ b/files/routes/static.py
@@ -197,7 +197,7 @@ def patrons(v):
 @app.get("/admins")
 @auth_desired
 def admins(v):
-	if v and v.admin_level > 2:
+	if v and v.admin_level >= 3:
 		admins = g.db.query(User).filter(User.admin_level>1).order_by(User.truecoins.desc()).all()
 		admins += g.db.query(User).filter(User.admin_level==1).order_by(User.truecoins.desc()).all()
 	else: admins = g.db.query(User).filter(User.admin_level>0).order_by(User.truecoins.desc()).all()
@@ -217,7 +217,7 @@ def log(v):
 
 	kind = request.values.get("kind")
 
-	if v and v.admin_level > 1:
+	if v and v.admin_level >= 2:
 		types = ACTIONTYPES
 	else:
 		types = ACTIONTYPES2
@@ -225,7 +225,7 @@ def log(v):
 	if kind not in types: kind = None
 
 	actions = g.db.query(ModAction)
-	if not (v and v.admin_level > 1): 
+	if not (v and v.admin_level >= 2): 
 		actions = actions.filter(ModAction.kind.notin_(["shadowban","unshadowban","flair_post","edit_post"]))
 	
 	if admin_id:
@@ -258,7 +258,7 @@ def log_item(v, id):
 
 	admins = [x[0] for x in g.db.query(User.username).filter(User.admin_level > 1).all()]
 
-	if v and v.admin_level > 1: types = ACTIONTYPES
+	if v and v.admin_level >= 2: types = ACTIONTYPES
 	else: types = ACTIONTYPES2
 
 	return render_template("log.html", v=v, actions=[action], next_exists=False, page=1, action=action, admins=admins, types=types)

--- a/files/templates/mobile_navigation_bar.html
+++ b/files/templates/mobile_navigation_bar.html
@@ -27,7 +27,7 @@
 								</div>
 						</a>
 				</button>
-				{% if v and v.admin_level > 1 %}
+				{% if v and v.admin_level >= 2 %}
 				<button class="col px-0 btn btn-dead m-0" style="background: None !important; border: None;">
 						<a href="/leaderboard" class="text-decoration-none" role="button">
 								<div class="text-center {% if request.path=='/leaderboard' %}text-primary{% else %}text-muted{% endif %}">

--- a/files/templates/notifications.html
+++ b/files/templates/notifications.html
@@ -28,7 +28,7 @@
 		Messages
 		</a>
 	</li>
-	{% if v.admin_level > 1 %}
+	{% if v.admin_level >= 2 %}
 		<li class="nav-item">
 			<a class="nav-link py-3{% if '/notifications?modmail=true' in request.full_path %} active{% endif %}" href="/notifications?modmail=true">
 			Modmail

--- a/files/templates/settings2.html
+++ b/files/templates/settings2.html
@@ -53,7 +53,7 @@
 <body id="settings2">
 {% include "header.html" %}
 {% block subNav %}
-{% set mod = (v and v.admin_level > 1) %}
+{% set mod = (v and v.admin_level >= 2) %}
 <div class="container-fluid bg-white d-none d-md-block" style="padding-top: 50px; padding-bottom: 0 !important;">
 	<div class="row box-shadow-bottom">
 			<div class="col">

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -120,7 +120,7 @@
 	</div>
 {% endif %}
 
-{% if v and v.admin_level > 1 %}
+{% if v and v.admin_level >= 2 %}
 	{% include "component/post/actions_admin_mobile.html" %}
 {% endif %}
 
@@ -146,7 +146,7 @@
 							<i class="{{a.class_list}} px-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{a.title}} Award given by @{{a.user.username}}"></i>
 						{% endfor %}
 
-						{% if v and v.admin_level > 1 and p.author.shadowbanned %}<i class="fas fa-user-times text-admin" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Shadowbanned by @{{p.author.shadowbanned}}"></i>{% endif %}
+						{% if v and v.admin_level >= 2 and p.author.shadowbanned %}<i class="fas fa-user-times text-admin" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Shadowbanned by @{{p.author.shadowbanned}}"></i>{% endif %}
 
 						{% if p.stickied %}
 							<i id='pinned-{{p.id}}' class="fas fa-thumbtack fa-rotate--45 text-admin" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Pinned by @{{p.stickied}}" {% if p.stickied_utc %}onmouseover="pinned_timestamp('pinned-{{p.id}}')" data-timestamp={{p.stickied_utc}} {% endif %}></i>
@@ -167,7 +167,7 @@
 							{% endif %}
 
 							<a href="/@{{p.author_name}}" class="user-name" onclick='popclick({{p.author.json_popover(v) | tojson}}); return false' data-bs-placement="bottom" data-bs-toggle="popover" data-bs-trigger="click" data-content-id="popover" role="button" tabindex="0" style="font-weight: bold"><img loading="lazy" src="{{p.author.profile_url}}" class="profile-pic-20 mr-2"><span {% if p.author.patron and not p.distinguish_level %}class="patron" style="background-color:#{{p.author.namecolor}};"{% elif p.distinguish_level %}class="mod"{% endif %}>{{p.author_name}}</span></a>{% if p.author.customtitle %}&nbsp;<bdi style="color: #{{p.author.titlecolor}}">&nbsp;{{p.author.customtitle | safe}}</bdi>{% endif %}
-							{% if v and v.admin_level > 1 %}
+							{% if v and v.admin_level >= 2 %}
 								<span 
 									class="usernote-link" 
 									data-micromodal-trigger="modal-1" 
@@ -368,7 +368,7 @@
 						<span class="text-info d-none {{p.id}}-new-comments"></span>
 					</a>
 
-					{% if v and v.admin_level > 1 %}
+					{% if v and v.admin_level >= 2 %}
 						<a class="ml-2" role="button" data-bs-toggle="modal" data-bs-target="#adminModal-{{p.id}}">
 							<i class="fas fa-broom"></i>
 						</a>
@@ -546,7 +546,7 @@
 	{% include "component/modal/report_post.html" %}
 {% endif %}
 
-{% if v and (v.id == p.author_id or v.admin_level > 1 and v.admin_level > 2) %}
+{% if v and (v.id == p.author_id or v.admin_level >= 2 and v.admin_level >= 3) %}
 	<script src="{{ 'js/togglePostEdit.js' | asset }}"></script>
 {% endif %}
 

--- a/files/templates/submission_banned.html
+++ b/files/templates/submission_banned.html
@@ -41,7 +41,7 @@
 														</div>
 
 												</div>
-			{% if v and v.admin_level > 1 and p.body_html %}
+			{% if v and v.admin_level >= 2 and p.body_html %}
 												<div class="post-body mt-4 mb-2"> 
 				{{p.body_html | safe}}
 			</div>

--- a/files/templates/submission_listing.html
+++ b/files/templates/submission_listing.html
@@ -4,7 +4,7 @@
 	<script src="{{ 'js/new_comments_count.js' | asset }}"></script>
 {% endif %}
 
-{% if v and v.admin_level > 1 %}
+{% if v and v.admin_level >= 2 %}
 	<script src="{{ 'js/filter_actions.js' | asset }}"></script>
 {% endif %}
 
@@ -168,7 +168,7 @@
 							{% endfor %}
 						{% endif %}
 
-						{% if v and v.admin_level > 1 and p.author.shadowbanned %}
+						{% if v and v.admin_level >= 2 and p.author.shadowbanned %}
 							<i class="fas fa-user-times text-admin" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Shadowbanned by @{{p.author.shadowbanned}}"></i>
 						{% endif %}
 
@@ -213,7 +213,7 @@
 												class="mod"
 											{% endif %}>{{p.author_name}}</span>
 								</a>{% if p.author.customtitle %}<bdi style="color: #{{p.author.titlecolor}}">&nbsp;&nbsp;{{p.author.customtitle | safe}}</bdi>{% endif %}
-								{% if v and v.admin_level > 1 %}
+								{% if v and v.admin_level >= 2 %}
 									<span 
 										class="usernote-link" 
 										data-micromodal-trigger="modal-1" 
@@ -249,7 +249,7 @@
 									<span class="text-info d-none {{p.id}}-new-comments"></span>
 								</a>
 			
-								{% if v and v.admin_level > 1 %}
+								{% if v and v.admin_level >= 2 %}
 									<a class="ml-2" role="button" data-bs-toggle="modal" data-bs-target="#adminModal-{{p.id}}">
 										<i class="fas fa-broom"></i>
 									</a>
@@ -301,7 +301,7 @@
 		{% endif %}
 	</script>
 
-	{% if v and v.admin_level > 1 %}
+	{% if v and v.admin_level >= 2 %}
 		{% include "component/post/actions_admin_mobile.html" %}
 	{% endif %}
 
@@ -384,7 +384,7 @@
 {% if v %}
 	{% include "component/modal/delete_post.html" %}
 	{% include "component/modal/report_post.html" %}
-	{% if v.admin_level > 1 %}
+	{% if v.admin_level >= 2 %}
 		{% include "component/modal/ban.html" %}
 	{% endif %}
 {% endif %}

--- a/files/templates/userpage.html
+++ b/files/templates/userpage.html
@@ -63,7 +63,7 @@
 									<span><i class="fas fa-badge-check align-middle ml-2 {% if u.verified=='Glowiefied' %}glow{% endif %}" style="color:{% if u.verifiedcolor %}#{{u.verifiedcolor}}{% else %}#1DA1F2{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{u.verified}}"></i></span>
 								{% endif %}
 
-								{% if u.admin_level > 1 or (u.admin_level == 1 and not(v and v.admin_level > 1)) %}
+								{% if u.admin_level > 1 or (u.admin_level == 1 and not(v and v.admin_level >= 2)) %}
 								<span>
 									<i class="fas fa-broom text-admin align-middle ml-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Admin"></i>
 								</span>
@@ -150,7 +150,7 @@
 						<a id="button-sub" class="btn btn-primary {% if is_following or u.is_nofollow or u.is_blocked %}d-none{% endif %}" role="button" onclick="post_toast2(this,'/follow/{{u.username}}','button-unsub','button-sub')">Follow</a>						
 						<a class="btn btn-primary" role="button" onclick="toggleElement('message', 'input-message')">Message</a>
 
-						{% if v and v.admin_level > 2 %}
+						{% if v and v.admin_level >= 3 %}
 							<a id="admin" class="{% if u.admin_level > 1 %}d-none{% endif %} btn btn-primary" href="javascript:void(0)" onclick="post_toast2(this,'/@{{u.username}}/make_admin','admin','unadmin')">Make admin</a>
 							<a id="unadmin" class="{% if u.admin_level < 2 %}d-none{% endif %} btn btn-primary" href="javascript:void(0)" onclick="post_toast2(this,'/@{{u.username}}/remove_admin','admin','unadmin')">Remove admin</a>
 							{% if u.admin_level > 1 %}
@@ -179,7 +179,7 @@
 						<a href="/views" class="btn btn-secondary">Profile views</a>
 					{% endif %}
 
-					{% if v and v.id != u.id and v.admin_level > 1 %}
+					{% if v and v.id != u.id and v.admin_level >= 2 %}
 						<br><br>
 						<div class="body d-lg-flex border-bottom">
 							<div class="w-lg-100">
@@ -229,7 +229,7 @@
 
 						<pre></pre>
 						
-						{% if v and v.admin_level > 2 %}
+						{% if v and v.admin_level >= 3 %}
 							<a id="verify" class="{% if u.verified %}d-none{% endif %} btn btn-success" role="button" onclick="post_toast2(this,'/admin/verify/{{u.id}}','verify','unverify')">Verify</a>
 							<a id="unverify" class="{% if not u.verified %}d-none{% endif %} btn btn-success" role="button" onclick="post_toast2(this,'/admin/unverify/{{u.id}}','verify','unverify')">Unverify</a>
 						{% endif %}
@@ -322,7 +322,7 @@
 					<span><i class="fas fa-badge-check align-middle ml-2 {% if u.verified=='Glowiefied' %}glow{% endif %}" style="color:{% if u.verifiedcolor %}#{{u.verifiedcolor}}{% else %}#1DA1F2{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{u.verified}}"></i></span>&nbsp;
 				{% endif %}
 
-				{% if u.admin_level > 1 or (u.admin_level == 1 and not(v and v.admin_level > 1)) %}
+				{% if u.admin_level > 1 or (u.admin_level == 1 and not(v and v.admin_level >= 2)) %}
 				<span>
 					<i class="fas fa-broom text-admin align-middle ml-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Admin"></i>
 				</span>
@@ -396,7 +396,7 @@
 					<a id="button-sub2" class="btn btn-primary {% if is_following or u.is_nofollow or u.is_blocked %}d-none{% endif %}" role="button" onclick="post_toast2(this,'/follow/{{u.username}}','button-unsub2','button-sub2')">Follow</a>						
 					<a class="btn btn-primary" role="button" onclick="toggleElement('message-mobile', 'input-message-mobile')">Message</a>
 
-					{% if v and v.admin_level > 2 %} 
+					{% if v and v.admin_level >= 3 %} 
 						<a id="admin2" class="{% if u.admin_level > 1 %}d-none{% endif %} btn btn-primary" href="javascript:void(0)" onclick="post_toast2(this,'/@{{u.username}}/make_admin','admin2','unadmin2')">Make admin</a>
 						<a id="unadmin2" class="{% if u.admin_level < 2 %}d-none{% endif %} btn btn-primary" href="javascript:void(0)" onclick="post_toast2(this,'/@{{u.username}}/remove_admin','admin2','unadmin2')">Remove admin</a>
 						{% if u.admin_level > 1 %}
@@ -420,7 +420,7 @@
 
 					<div id="message-preview-mobile" class="preview my-3"></div>
 
-					{% if v and v.admin_level > 1 %}
+					{% if v and v.admin_level >= 2 %}
 
 					<button id="grant" class="{% if u.paid_dues %}d-none{% endif %} btn btn-success" onclick="post_toast2(this,'/@{{u.username}}/club_allow','grant','bar')">Grant club access</button>
 					<button id="bar" class="{% if u.club_allowed == False %}d-none{% endif %} btn btn-danger" onclick="post_toast2(this,'/@{{u.username}}/club_ban','grant','bar')">Bar from club</button>
@@ -477,7 +477,7 @@
 
 						<pre></pre>
 
-						{% if v and v.admin_level > 2 %}
+						{% if v and v.admin_level >= 3 %}
 							<a id="verify2" class="{% if u.verified %}d-none{% endif %} btn btn-success" role="button" onclick="post_toast2(this,'/admin/verify/{{u.id}}','verify2','unverify2')">Verify</a>
 							<a id="unverify2" class="{% if not u.verified %}d-none{% endif %} btn btn-success" role="button" onclick="post_toast2(this,'/admin/unverify/{{u.id}}','verify2','unverify2')">Unverify</a>
 						{% endif %}


### PR DESCRIPTION
places that use the PERMS constant do it and this way makes it clearer what admin level is required to perform an action.