### PR TITLE
Remove a no-longer-needed permalink

### DIFF
--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -415,11 +415,6 @@
 	<div class="col border-top">
 		<div class="comments-count py-3">
 			{{sorting_time.sort_dropdown(sort, none, SORTS_COMMENTS)}}
-			{% if comment_info and p.comment_count >= 2 %}
-			<div class="total mt-3">
-				<a href="{{p.permalink}}">View entire discussion</a>
-			</div>
-			{% endif %}
 		</div>
 
 	{% if v %}


### PR DESCRIPTION
I think this may not be necessary because the context page is the same as the full permalink page. Also the formatting of this link looks bad. Is there any way the two are still different?