### PR TITLE
Fixes #574: case-insensitive `@mention` linkifying

### DIFF
--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -230,8 +230,8 @@ def sanitize(sanitized, alert=False, comment=False, edit=False):
 
 		for u in users:
 			if not u: continue
-			m = [ m for m in matches if u.username == m.group(2) or u.original_username == m.group(2) ]
-			for i in m:
+			mention_is_u = lambda m: m.group(2).lower() in (u.username.lower(), u.original_username.lower())
+			for i in filter(mention_is_u, matches):
 				if not (g.v and g.v.any_block_exists(u)) or g.v.admin_level >= 2:
 					sanitized = sanitized.replace(i.group(0), f'''{i.group(1)}<a href="/id/{u.id}"><img loading="lazy" src="/pp/{u.id}">@{u.username}</a>''', 1)
 


### PR DESCRIPTION
Investigation of why `@tyre_inflator` didn't appear to ping `@Tyre_Inflator` revealed that the alerts/notifications system is correctly case-insensitive. However, the logic in `sanitize` that converts `@mention`s into user profile links was case-sensitive. We resolve that here the naive way by normalizing case while comparing.

![image](https://user-images.githubusercontent.com/104547575/230746810-db55b983-20ae-49c4-a7a6-1f9c95601236.png)
