### PR TITLE
fix: monospace line spacing issue #235

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -108,7 +108,6 @@ pre, code, kbd, samp {
 pre {
 	margin-top: 0;
 	margin-bottom: 1rem;
-	overflow: auto;
 }
 figure {
 	margin: 0 0 1rem;
@@ -5362,4 +5361,8 @@ div[id^="reply-edit-"] li > p:first-child {
 
 .volunteer_janitor_result_bad_3 {
 	background-color: hsl(0, 100%, 80%);
+}
+
+pre {
+	line-height: .5rem;
 }


### PR DESCRIPTION
-> https://github.com/themotte/rDrama/issues/253

i removed `overflow: auto` because it causes the codeblock to vertical scroll when the line height is decreased