### PR TITLE
fix: username popover listener on comment reply

### DIFF
--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -290,9 +290,9 @@ function post_comment(fullname,id,level = 1){
 			let comments = document.getElementById('replies-of-' + id);
 			let comment = data["comment"].replace(/data-src/g, 'src').replace(/data-cfsrc/g, 'src').replace(/style="display:none;visibility:hidden;"/g, '');
 
-			comments.innerHTML = comment + comments.innerHTML;
+			comments.insertAdjacentHTML('afterbegin', comment);
 
-			bs_trigger(commentForm);
+			bs_trigger(comments);
 
 			// remove the placeholder if it exists
 			let placeholder = document.getElementById("placeholder-comment");


### PR DESCRIPTION
Fixes #612. Ports in an existing working fix from upstream with the change to bs_trigger. Also a stylistic improvement on the preceding line I noticed while porting it.

bs_trigger is what attaches the event listeners for the Boostrap popovers. It wasn't being called on the new elements, so they get no user card. It is now, so it does. Calling it on the comment form element doesn't work here because, unlike in an earlier stage of the codebase (which I think the fork occured during the transition of) put replies into a dedicated element rather than replacing the reply form.