### PR TITLE
Comment notifications cleanup (#476 ish)

### DIFF
--- a/files/classes/comment.py
+++ b/files/classes/comment.py
@@ -359,7 +359,7 @@ class Comment(CreatedBase):
 		return self.is_message and not self.sentto
 
 	@lazy
-	def header_msg(self, v, is_notification_page:bool, reply_count:int) -> str:
+	def header_msg(self, v, is_notification_page: bool) -> str:
 		'''
 		Returns a message that is in the header for a comment, usually for
 		display on a notification page.
@@ -367,9 +367,9 @@ class Comment(CreatedBase):
 		if self.post:
 			post_html:str = f"<a href=\"{self.post.permalink}\">{self.post.realtitle(v)}</a>"
 			if v:
-				if v.id == self.author_id and reply_count:
-					text = f"Comment {'Replies' if reply_count != 1 else 'Reply'}"
-				elif v.id == self.post.author_id and self.level == 1:
+				if self.level > 1 and v.id == self.parent_comment.author_id:
+					text = "Comment Reply"
+				elif self.level == 1 and v.id == self.post.author_id:
 					text = "Post Reply"
 				elif self.parent_submission in v.subscribed_idlist():
 					text = "Subscribed Thread"

--- a/files/classes/user.py
+++ b/files/classes/user.py
@@ -350,23 +350,13 @@ class User(CreatedBase):
 
 	@property
 	@lazy
-	def reddit_notifications_count(self):
-		return g.db.query(Notification.user_id).join(Comment).filter(Notification.user_id == self.id, Notification.read == False, Comment.state_mod == StateMod.VISIBLE, Comment.state_user_deleted_utc == None, Comment.body_html.like('%<p>New site mention: <a href="https://old.reddit.com/r/%'), Comment.parent_submission == None, Comment.author_id == NOTIFICATIONS_ID).count()
-
-	@property
-	@lazy
 	def normal_count(self):
-		return self.notifications_count - self.post_notifications_count - self.reddit_notifications_count
+		return self.notifications_count - self.post_notifications_count
 
 	@property
 	@lazy
 	def do_posts(self):
-		return self.post_notifications_count and self.notifications_count-self.reddit_notifications_count == self.post_notifications_count
-
-	@property
-	@lazy
-	def do_reddit(self):
-		return self.notifications_count == self.reddit_notifications_count
+		return self.post_notifications_count and self.notifications_count == self.post_notifications_count
 
 	@property
 	@lazy

--- a/files/helpers/services.py
+++ b/files/helpers/services.py
@@ -26,7 +26,7 @@ def pusher_thread2(interests, notifbody, username):
 				'notification': {
 					'title': f'New message from @{username}',
 					'body': notifbody,
-					'deep_link': f'{SITE_FULL}/notifications?messages=true',
+					'deep_link': f'{SITE_FULL}/notifications/messages',
 					'icon': SITE_FULL + assetcache_path(f'images/{SITE_ID}/icon.webp'),
 				}
 			},
@@ -36,7 +36,7 @@ def pusher_thread2(interests, notifbody, username):
 					'body': notifbody,
 				},
 				'data': {
-					'url': '/notifications?messages=true',
+					'url': '/notifications/messages',
 				}
 			}
 		},

--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -540,7 +540,7 @@ def messagereply(v):
 						'notification': {
 							'title': f'New message from @{v.username}',
 							'body': notifbody,
-							'deep_link': f'{SITE_FULL}/notifications?messages=true',
+							'deep_link': f'{SITE_FULL}/notifications/messages',
 							'icon': SITE_FULL + assetcache_path(f'images/{SITE_ID}/icon.webp'),
 						}
 					},
@@ -550,7 +550,7 @@ def messagereply(v):
 							'body': notifbody,
 						},
 						'data': {
-							'url': '/notifications?messages=true',
+							'url': '/notifications/messages',
 						}
 					}
 				},

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -10,7 +10,6 @@
 	{%- set score = c.score_str(render_ctx) -%}
 	{%- set downs = c.downvotes_str(render_ctx) -%}
 	{% set replies = c.replies(v) %}
-	{%- set is_notification_page = request.path.startswith('/notifications') -%}
 
 {% if not c.visibility_state(v)[0] %}
 {% if c.show_descendants(v) %}
@@ -61,10 +60,10 @@
 {%- set voted = c.voted_display(v) -%}
 
 {% if standalone and level==1 %}
-<div class="post-info post-row-cid-{{c.id}} mb-1 mr-2 {% if is_notification_page %}mt-5{% else %}mt-3{% endif %}">
+<div class="post-info post-row-cid-{{c.id}} mb-1 mr-2 mt-3">
 	{% if c.post and c.post.over_18 %}<span class="badge badge-danger text-small-extra mr-1">+18</span>{% endif %}
 	<span class="align-top">
-		<span class="font-weight-bold">{{c.header_msg(v, is_notification_page, replies | length) | safe}}</span>
+		<span class="font-weight-bold">{{c.header_msg(v, is_notification_page) | safe}}</span>
 	</span>
 </div>
 {% endif %}

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -27,7 +27,7 @@
 
 			{% if v %}
 				{% if v.notifications_count %}
-					<a class="mobile-nav-icon d-md-none pl-0" href="/notifications{% if v.do_posts %}?posts=true{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell align-middle text-danger" {% if v.do_posts %}style="color:blue!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% endif %}">{{v.notifications_count}}</span></a>
+					<a class="mobile-nav-icon d-md-none pl-0" href="/notifications{% if v.do_posts %}/posts{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell align-middle text-danger" {% if v.do_posts %}style="color:blue!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% endif %}">{{v.notifications_count}}</span></a>
 				{% else %}
 					<a class="mobile-nav-icon d-md-none" href="/notifications" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell  align-middle text-gray-500 black"></i></a>
 				{% endif %}
@@ -57,7 +57,7 @@
 				{% if v.notifications_count %}
 
 				<li class="nav-item d-flex align-items-center text-center justify-content-center mx-1">
-					<a class="nav-link position-relative" href="/notifications{% if v.do_posts %}?posts=true{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell text-danger" {% if v.do_posts %}style="color:blue!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% endif %}">{{v.notifications_count}}</span></a>
+					<a class="nav-link position-relative" href="/notifications{% if v.do_posts %}/posts{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell text-danger" {% if v.do_posts %}style="color:blue!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% endif %}">{{v.notifications_count}}</span></a>
 				</li>
 
 				{% else %}

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -27,7 +27,7 @@
 
 			{% if v %}
 				{% if v.notifications_count %}
-					<a class="mobile-nav-icon d-md-none pl-0" href="/notifications{% if v.do_posts %}?posts=true{% elif v.do_reddit %}?reddit=true{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell align-middle text-danger" {% if v.do_posts %}style="color:blue!important"{% elif v.do_reddit %}style="color:#805ad5!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% elif v.do_reddit %}background:#805ad5{% endif %}">{{v.notifications_count}}</span></a>
+					<a class="mobile-nav-icon d-md-none pl-0" href="/notifications{% if v.do_posts %}?posts=true{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell align-middle text-danger" {% if v.do_posts %}style="color:blue!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% endif %}">{{v.notifications_count}}</span></a>
 				{% else %}
 					<a class="mobile-nav-icon d-md-none" href="/notifications" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell  align-middle text-gray-500 black"></i></a>
 				{% endif %}
@@ -57,7 +57,7 @@
 				{% if v.notifications_count %}
 
 				<li class="nav-item d-flex align-items-center text-center justify-content-center mx-1">
-					<a class="nav-link position-relative" href="/notifications{% if v.do_posts %}?posts=true{% elif v.do_reddit %}?reddit=true{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell text-danger" {% if v.do_posts %}style="color:blue!important"{% elif v.do_reddit %}style="color:#805ad5!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% elif v.do_reddit %}background:#805ad5{% endif %}">{{v.notifications_count}}</span></a>
+					<a class="nav-link position-relative" href="/notifications{% if v.do_posts %}?posts=true{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications"><i class="fas fa-bell text-danger" {% if v.do_posts %}style="color:blue!important"{% endif %}></i><span class="notif-count ml-1" style="padding-left: 4.5px;{% if v.do_posts %}background:blue{% endif %}">{{v.notifications_count}}</span></a>
 				</li>
 
 				{% else %}

--- a/files/templates/notifications.html
+++ b/files/templates/notifications.html
@@ -40,7 +40,7 @@
 </div>
 
 
-<a class="btn btn-primary mt-3 ml-3" role="button" onclick="post_toast(this,'/clear', '1')">Clear all notifications</a>
+<a class="btn btn-primary mt-3 ml-3" role="button" onclick="post_toast(this, '/clear', '1')">Mark All Read</a>
 
 <div class="notifs px-3 p-md-0">
 

--- a/files/templates/notifications.html
+++ b/files/templates/notifications.html
@@ -35,13 +35,6 @@
 			</a>
 		</li>
 	{% endif %}
-	{% if v.admin_level %}
-		<li class="nav-item">
-			<a class="nav-link py-3{% if '/notifications?reddit=true' in request.full_path %} active{% endif %}" href="/notifications?reddit=true">
-			Reddit {% if v.reddit_notifications_count %}<span class="font-weight-bold" style="color:#805ad5">({{v.reddit_notifications_count}})</span>{% endif %}
-			</a>
-		</li>
-	{% endif %}
 	</ul>
   </div>
 </div>

--- a/files/templates/notifications.html
+++ b/files/templates/notifications.html
@@ -19,18 +19,18 @@
 		</a>
 	</li>
 	<li class="nav-item">
-		<a class="nav-link py-3{% if '/notifications?posts=true' in request.full_path %} active{% endif %}" href="/notifications?posts=true">
+		<a class="nav-link py-3{% if '/notifications/posts' in request.full_path %} active{% endif %}" href="/notifications/posts">
 		Posts {% if v.post_notifications_count %}<span class="font-weight-bold" style="color:blue">({{v.post_notifications_count}})</span>{% endif %}
 		</a>
 	</li>
 	<li class="nav-item">
-		<a class="nav-link py-3{% if '/notifications?messages=true' in request.full_path %} active{% endif %}" href="/notifications?messages=true">
+		<a class="nav-link py-3{% if '/notifications/messages' in request.full_path %} active{% endif %}" href="/notifications/messages">
 		Messages
 		</a>
 	</li>
 	{% if v.admin_level >= 2 %}
 		<li class="nav-item">
-			<a class="nav-link py-3{% if '/notifications?modmail=true' in request.full_path %} active{% endif %}" href="/notifications?modmail=true">
+			<a class="nav-link py-3{% if '/notifications/modmail' in request.full_path %} active{% endif %}" href="/notifications/modmail">
 			Modmail
 			</a>
 		</li>


### PR DESCRIPTION
The story of this PR is that I set out to address #476, hard wrapped some lines to make it easier to reason about, changed the notification subpages to use real paths rather than query string parameters, and realized that we probably mostly fixed the issue with one of the many comment filtering / moderation state / comment_on_publish reworks.

Our notifications logic is nearly identical to upstream differing mainly in: upstream sorts comment replies by new, whereas ours was by old. This has been remedied (as [suggested in the meta thread at the time](https://www.themotte.org/post/216/meta-something-shiny-and-two-things/56269?context=8#context)).

Given that the issue doesn't exist on upstream, my theory is it's because of fork-specific comment filtering code. A reply can still get quasi-buried through the following sequence: 1) a reply is filtered, 2) a different unfiltered reply is made, 3) the first reply is then unfiltered. These will appear sorted by submission time descending, not by first time visible descending, which may be perceived as burial, though the notification bell will still light up. We don't have the data readily available in the schema to fix this with the context-included approach, though sort-by-new may ameliorate this in practice. 

NB: if we wanted to go to reddit-style comment notifications (just the reply, no context), it would be trivial to do so and _would_ truly solve the aforementioned scenario where initially-filtered comments can be buried. Am willing to amend PR if this is requested.

tl;dr— actual function differences: `/notifications?messages=true` → `/notifications/messages` (etc), comment replies in notifs are sorted by new. Code broken up into more readable blocks. 