### PR TITLE
fix: change logo image to text

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -2785,6 +2785,15 @@ ol > li::before {
 #logo {
 	margin-left: 0.5rem;
 }
+.logo-text {
+	font-size: 1.5rem;
+	font-weight: 700;
+	color: var(--black)
+}
+.logo-text:hover {
+	text-decoration: none;
+	color: var(--black)
+}
 .navbar-brand, .navbar-light .navbar-brand {
 	color: var(--primary);
 	font-weight: 600;

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -6,8 +6,8 @@
 				<img alt="header icon" height=33 width=80 src="{{ ('images/'~SITE_ID~'/headericon.webp') | asset }}">
 			</a>
 			
-			<a href="/" class="flex-grow-1">
-				<img id="logo" alt="logo" src="{{ ('images/'~SITE_ID~'/logo.webp') | asset }}" width="100" height="20">
+			<a href="/" id="logo" class="flex-grow-1 logo-text">
+				{{SITE_TITLE}}
 			</a>
 
 			<div class="flex-grow-1 d-fl d-none d-md-block {% if not v %}pad{% endif %}">


### PR DESCRIPTION
Small change to fix #179 . Looks good on themes although is not the same font as the image, just the default one.