### PR TITLE
Add unsupported theme tag on profile setting #378

### DIFF
--- a/files/assets/css/dramblr.css
+++ b/files/assets/css/dramblr.css
@@ -13,6 +13,7 @@
 	--gray-800: #1e293b;
 	--gray-900: #0f172a;
 	--background: #2d3c50;
+	--white: #fff;
 }
 
 body, .container.transparent, .card {
@@ -140,4 +141,12 @@ color: var(--gray-700);
 
 #frontpage .post-title a:visited, .visited {
 	color: #6e6e6e !important;
+}
+
+.custom-switch .custom-control-label::after {
+	background-color: var(--white);
+}
+
+.bg-white {
+	background-color: var(--background) !important;
 }

--- a/files/templates/settings_profile.html
+++ b/files/templates/settings_profile.html
@@ -51,8 +51,10 @@
 								{% endfor %}
 							</select>
 							</div>
+							<span class="text-small-extra text-muted">Themes are not officially supported. If you run into an issue, please report it or submit a pull request.</span>
 						</div>
 				</div>
+			</div>
 
 			<h2 class="h5">Profile Picture</h2>
 			<div class="settings-section rounded">


### PR DESCRIPTION
Adds the tag message for #378, also the profile setting had a style issue because of a missing div.

And a couple of tweaks for dramblr theme, the switch button wasn't visible.