### PR TITLE
fix: filtered posts on frontpage listing

### DIFF
--- a/files/helpers/listing.py
+++ b/files/helpers/listing.py
@@ -45,7 +45,7 @@ def frontlist(v=None, sort='new', page=1, t="all", ids_only=True, ccmode="false"
 	if (ccmode == "true"):
 		posts = posts.filter(Submission.club == True)
 
-	posts = posts.filter_by(state_mod=StateMod.VISIBLE, private=False, state_user_deleted_utc=None)
+	posts = posts.filter_by(private=False, state_user_deleted_utc=None)
 
 	if ccmode == "false" and not gt and not lt:
 		posts = posts.filter_by(stickied=None)


### PR DESCRIPTION
Desired behavior for new posts when FilterNewPosts setting is enabled is that people with admin_level >= 2 and post authors should see their post on the frontpage, while all other unprivileged users shouldn't.

The logic for this is already in `files.helpers.listing` but it was overridden by a second filter condition which required `state_mod = VISIBLE`.

`(state_mod = VISIBLE | author_id = v.id) & (state_mod = VISIBLE)` simplifies in an unfortunate way. The latter condition was also not conditional on admin_level. Simply removing it fixes the listing for both post authors and privileged users.