### PR TITLE
combine 5 different post/comment filter state adjustment routes

### DIFF
--- a/files/assets/js/comments_admin.js
+++ b/files/assets/js/comments_admin.js
@@ -1,22 +1,18 @@
 function removeCommentBackend(post_id) {
-	url="/remove_comment/"+post_id
-
-	post(url)
+	filter_new_comment_status(post_id, "removed");
 }
 
 function approveCommentBackend(post_id) {
-	url="/unremove_comment/"+post_id
-
-	post(url)
+	filter_new_comment_status(post_id, "normal");
 }
 
 function removeCommentDesktop(post_id,button1,button2) {
-	removeCommentBackend(post_id)
+	removeCommentBackend(post_id);
 
 	try {
-		document.getElementById("comment-"+post_id+"-only").classList.add("banned");
+		document.getElementById("comment-"+post_id+"-only").classList.add("removed");
 	} catch(e) {
-		document.getElementById("context").classList.add("banned");
+		document.getElementById("context").classList.add("removed");
 	}
 
 	var button=document.getElementById("remove-"+post_id);
@@ -33,9 +29,9 @@ function approveCommentDesktop(post_id,button1,button2) {
 	approveCommentBackend(post_id)
 
 	try {
-		document.getElementById("comment-"+post_id+"-only").classList.remove("banned");
+		document.getElementById("comment-"+post_id+"-only").classList.remove("removed");
 	} catch(e) {
-		document.getElementById("context").classList.remove("banned");
+		document.getElementById("context").classList.remove("removed");
 	}
 	
 	var button=document.getElementById("remove-"+post_id);

--- a/files/assets/js/comments_admin.js
+++ b/files/assets/js/comments_admin.js
@@ -1,74 +1,23 @@
-function removeCommentBackend(post_id) {
-	filter_new_comment_status(post_id, "removed");
-}
-
-function approveCommentBackend(post_id) {
-	filter_new_comment_status(post_id, "normal");
-}
-
-function removeCommentDesktop(post_id,button1,button2) {
-	removeCommentBackend(post_id);
-
-	try {
-		document.getElementById("comment-"+post_id+"-only").classList.add("removed");
-	} catch(e) {
-		document.getElementById("context").classList.add("removed");
+function moderate(isPost, id, removing, removeButtonDesktopId, removeButtonMobileId, approveButtonDesktopId, approveButtonMobileId) {
+	const filterState = removing ? "removed" : "normal";
+	if (isPost) {
+		filter_new_status(id, filterState);
+	} else {
+		filter_new_comment_status(id, filterState);
 	}
-
-	var button=document.getElementById("remove-"+post_id);
-	button.onclick=function(){approveCommentDesktop(post_id)};
-	button.innerHTML='<i class="fas fa-clipboard-check"></i>Approve'
-
-	if (typeof button1 !== 'undefined') {
-		document.getElementById(button1).classList.toggle("d-md-inline-block");
-		document.getElementById(button2).classList.toggle("d-md-inline-block");
-	}
-};
-
-function approveCommentDesktop(post_id,button1,button2) {
-	approveCommentBackend(post_id)
-
-	try {
-		document.getElementById("comment-"+post_id+"-only").classList.remove("removed");
-	} catch(e) {
-		document.getElementById("context").classList.remove("removed");
-	}
-	
-	var button=document.getElementById("remove-"+post_id);
-	button.onclick=function(){removeCommentDesktop(post_id)};
-	button.innerHTML='<i class="fas fa-trash-alt"></i>Remove'
-
-	if (typeof button1 !== 'undefined') {
-		document.getElementById(button1).classList.toggle("d-md-inline-block");
-		document.getElementById(button2).classList.toggle("d-md-inline-block");
-	}
-}
-
-
-function removeCommentMobile(post_id,button1,button2) {
-	removeCommentBackend(post_id)
-
-	document.getElementById("comment-"+post_id+"-only").classList.add("banned");
-	var button=document.getElementById("remove-"+post_id);
-	button.onclick=function(){approveCommentMobile(post_id)};
-	button.innerHTML='<i class="fas fa-clipboard-check"></i>Approve'
-
-	if (typeof button1 !== 'undefined') {
-		document.getElementById(button1).classList.toggle("d-none");
-		document.getElementById(button2).classList.toggle("d-none");
-	}
-};
-
-function approveCommentMobile(post_id,button1,button2) {
-	approveCommentBackend(post_id)
-
-	document.getElementById("comment-"+post_id+"-only").classList.remove("banned");
-	var button=document.getElementById("remove-"+post_id);
-	button.onclick=function(){removeCommentMobile(post_id)};
-	button.innerHTML='<i class="fas fa-trash-alt"></i>Remove'
-
-	if (typeof button1 !== 'undefined') {
-		document.getElementById(button1).classList.toggle("d-none");
-		document.getElementById(button2).classList.toggle("d-none");
+	const removeButtonDesktop = document.getElementById(removeButtonDesktopId);
+	const removeButtonMobile = document.getElementById(removeButtonMobileId);
+	const approveButtonDesktop = document.getElementById(approveButtonDesktopId);
+	const approveButtonMobile = document.getElementById(approveButtonMobileId);
+	if (removing) {
+		removeButtonDesktop.classList.add("d-none");
+		removeButtonMobile.classList.add("d-none");
+		approveButtonDesktop.classList.remove("d-none");
+		approveButtonMobile.classList.remove("d-none");
+	} else {
+		removeButtonDesktop.classList.remove("d-none");
+		removeButtonMobile.classList.remove("d-none");
+		approveButtonDesktop.classList.add("d-none");
+		approveButtonMobile.classList.add("d-none");
 	}
 }

--- a/files/classes/mod_logs.py
+++ b/files/classes/mod_logs.py
@@ -85,6 +85,26 @@ class ModAction(CreatedBase):
 		return f"/log/{self.id}"	
 
 ACTIONTYPES = {
+	'approve_post': {
+		"str": 'approved post {self.target_link}', 
+		"icon": 'fa-feather-alt', 
+		"color": 'bg-success'
+	},
+	'approve_comment': {
+		"str": 'approved {self.target_link}', 
+		"icon": 'fa-comment', 
+		"color": 'bg-success'
+	},
+	'remove_post': {
+		"str": 'removed post {self.target_link}', 
+		"icon": 'fa-feather-alt', 
+		"color": 'bg-danger'
+	},
+	'remove_comment': {
+		"str": 'removed {self.target_link}', 
+		"icon": 'fa-comment', 
+		"color": 'bg-danger'
+	},
 	'approve_app': {
 		"str": 'approved an application by {self.target_link}', 
 		"icon": 'fa-robot', 
@@ -100,19 +120,9 @@ ACTIONTYPES = {
 		"icon": 'fa-badge', 
 		"color": 'bg-danger'
 	},
-	'remove_comment': {
-		"str": 'removed {self.target_link}', 
-		"icon": 'fa-comment', 
-		"color": 'bg-danger'
-	},
 	'ban_domain': {
 		"str": 'banned a domain', 
 		"icon": 'fa-globe', 
-		"color": 'bg-danger'
-	},
-	'remove_post': {
-		"str": 'removed post {self.target_link}', 
-		"icon": 'fa-feather-alt', 
 		"color": 'bg-danger'
 	},
 	'ban_user': {
@@ -300,19 +310,9 @@ ACTIONTYPES = {
 		"icon": 'fa-eye-slash', 
 		"color": 'bg-danger'
 	},
-	'unremove_comment': {
-		"str": 'reinstated {self.target_link}', 
-		"icon": 'fa-comment', 
-		"color": 'bg-success'
-	},
 	'unban_domain': {
 		"str": 'unbanned a domain', 
 		"icon": 'fa-globe', 
-		"color": 'bg-success'
-	},
-	'unremove_post': {
-		"str": 'reinstated post {self.target_link}', 
-		"icon": 'fa-feather-alt', 
 		"color": 'bg-success'
 	},
 	'unban_user': {

--- a/files/routes/admin/admin.py
+++ b/files/routes/admin/admin.py
@@ -272,14 +272,14 @@ def filtered_comments(v):
 # (also rename Unremove to Approve, sigh)
 @app.post("/admin/update_filter_status")
 @limiter.exempt
-@admin_level_required(2)
+@admin_level_required(PERMS['POST_COMMENT_MODERATION'])
 def update_filter_status(v):
 	update_body = request.get_json()
 	new_status = update_body.get('new_status')
 	post_id = update_body.get('post_id')
 	comment_id = update_body.get('comment_id')
 	if new_status not in ['normal', 'removed', 'ignored']:
-		return { 'result': f'Status of {new_status} is not permitted' }
+		return {'result': f'Status of {new_status} is not permitted'}, 403
 
 	if new_status == 'normal':
 		state_mod_new = StateMod.VISIBLE
@@ -292,43 +292,45 @@ def update_filter_status(v):
 		state_report_new = StateReport.IGNORED
 
 	if post_id:
-		target = g.db.get(Submission, post_id)
-		old_status = target.state_mod
-
-		# this could totally be one query but it would be kinda ugly
-		if state_mod_new is not None:
-			g.db.query(Submission).where(Submission.id == post_id) \
-								.update({Submission.state_mod: state_mod_new, Submission.state_mod_set_by: v.username})
-		g.db.query(Submission).where(Submission.id == post_id) \
-								.update({Submission.state_report: state_report_new})
+		target: Submission = get_post(post_id, graceful=True)
+		modlog_target_type: str = 'post'
 	elif comment_id:
-		target = g.db.get(Comment, comment_id)
-		old_status = target.state_mod
-		
-		if state_mod_new is not None:
-			g.db.query(Comment).where(Comment.id == comment_id) \
-								.update({Comment.state_mod: state_mod_new, Comment.state_mod_set_by: v.username})
-		g.db.query(Comment).where(Comment.id == comment_id) \
-								.update({Comment.state_report: state_report_new})
+		target: Comment = get_comment(comment_id, graceful=True)
+		modlog_target_type: str = 'comment'
 	else:
-		return { 'result': f'No valid item ID provided' }
+		return {"result": "No valid item ID provided"}, 404
+	
+	if not target:
+		return {"result": "Item ID does not exist"}, 404
 
-	if target is not None:
-		# If comment now visible, update state to reflect publication.
-		if (isinstance(target, Comment)
-				and old_status != StateMod.VISIBLE
-				and state_mod_new == StateMod.VISIBLE):
-			comment_on_publish(target) # XXX: can cause discrepancies if removal state ≠ filter state
+	old_status = target.state_mod
 
-		if (isinstance(target, Comment)
-				and old_status == StateMod.VISIBLE
-				and state_mod_new != StateMod.VISIBLE and state_mod_new is not None):
-			comment_on_unpublish(target) # XXX: can cause discrepancies if removal state ≠ filter state
+	if state_mod_new is not None:
+		target.state_mod = state_mod_new
+		target.state_mod_set_by = v.username
+	target.state_report = state_report_new
 
-		g.db.commit()
-		return { 'result': 'Update successful' }
-	else:
-		return { 'result': 'Item ID does not exist' }
+	making_visible: bool = old_status != StateMod.VISIBLE and state_mod_new == StateMod.VISIBLE
+	making_invisible: bool = old_status == StateMod.VISIBLE and state_mod_new != StateMod.VISIBLE and state_mod_new is not None
+
+	if making_visible:
+		modlog_action: str = "approve"
+		if isinstance(target, Comment): comment_on_publish(target)
+	elif making_invisible:
+		modlog_action: str = "remove"
+		if isinstance(target, Comment): comment_on_unpublish(target)
+
+	if making_visible or making_invisible:
+		g.db.add(ModAction(
+			kind=f"{modlog_action}_{modlog_target_type}",
+			user_id=v.id,
+			target_submission_id=target.id if isinstance(target, Submission) else None,
+			target_comment_id=target.id if isinstance(target, Comment) else None
+		))
+
+	g.db.commit()
+	invalidate_cache(frontlist=True)
+	return { 'result': 'Update successful' }
 
 @app.get("/admin/image_posts")
 @limiter.exempt
@@ -1100,74 +1102,6 @@ def unban_user(user_id, v):
 	else: return {"message": f"@{user.username} was unbanned!"}
 
 
-@app.post("/remove_post/<post_id>")
-@limiter.exempt
-@admin_level_required(2)
-def remove_post(post_id, v):
-	post = g.db.query(Submission).filter_by(id=post_id).one_or_none()
-
-	if not post:
-		abort(400)
-
-	post.state_mod = StateMod.REMOVED
-	post.state_mod_set_by = v.username
-	post.stickied = None
-	post.is_pinned = False
-	g.db.add(post)
-
-	
-
-	ma=ModAction(
-		kind="remove_post",
-		user_id=v.id,
-		target_submission_id=post.id,
-		)
-	g.db.add(ma)
-
-	invalidate_cache(frontlist=True)
-
-	v.coins += 1
-	g.db.add(v)
-
-	requests.post(f'https://api.cloudflare.com/client/v4/zones/{CF_ZONE}/purge_cache', headers=CF_HEADERS, json={'files': [f"{SITE_FULL}/logged_out/"]}, timeout=5)
-
-	g.db.commit()
-
-	return {"message": "Post removed!"}
-
-
-@app.post("/unremove_post/<post_id>")
-@limiter.exempt
-@admin_level_required(2)
-def unremove_post(post_id, v):
-	post = g.db.query(Submission).filter_by(id=post_id).one_or_none()
-
-	if not post:
-		abort(400)
-
-	if post.state_mod != StateMod.VISIBLE:
-		ma=ModAction(
-			kind="unremove_post",
-			user_id=v.id,
-			target_submission_id=post.id,
-		)
-		g.db.add(ma)
-
-	post.state_mod = StateMod.VISIBLE
-	post.state_mod_set_by = v.username
-
-	g.db.add(post)
-
-	invalidate_cache(frontlist=True)
-
-	v.coins -= 1
-	g.db.add(v)
-
-	g.db.commit()
-
-	return {"message": "Post approved!"}
-
-
 @app.post("/distinguish/<post_id>")
 @limiter.exempt
 @admin_level_required(1)
@@ -1307,59 +1241,10 @@ def unsticky_comment(cid, v):
 	return {"message": "Comment unpinned!"}
 
 
-@app.post("/remove_comment/<c_id>")
-@limiter.exempt
-@admin_level_required(2)
-def api_remove_comment(c_id, v):
-	comment = g.db.query(Comment).filter_by(id=c_id).one_or_none()
-	if not comment:
-		abort(404)
-
-	comment.state_mod = StateMod.REMOVED
-	comment.state_mod_set_by = v.username
-	comment_on_unpublish(comment) # XXX: can cause discrepancies if removal state ≠ filter state
-	ma=ModAction(
-		kind="remove_comment",
-		user_id=v.id,
-		target_comment_id=comment.id,
-		)
-	g.db.add(ma)
-	g.db.commit()
-	return {"message": "Comment removed!"}
-
-
-@app.post("/unremove_comment/<c_id>")
-@limiter.exempt
-@admin_level_required(2)
-def api_unremove_comment(c_id, v):
-	comment = g.db.query(Comment).filter_by(id=c_id).one_or_none()
-	if not comment: abort(404)
-	
-	if comment.state_mod == StateMod.REMOVED:
-		ma=ModAction(
-			kind="unremove_comment",
-			user_id=v.id,
-			target_comment_id=comment.id,
-			)
-		g.db.add(ma)
-
-	comment.state_mod = StateMod.VISIBLE
-	comment.state_mod_set_by = v.username
-	comment_on_publish(comment) # XXX: can cause discrepancies if removal state ≠ filter state
-
-	g.db.add(comment)
-
-	g.db.commit()
-
-	return {"message": "Comment approved!"}
-
-
 @app.post("/distinguish_comment/<c_id>")
 @limiter.exempt
 @admin_level_required(1)
 def admin_distinguish_comment(c_id, v):
-	
-	
 	comment = get_comment(c_id, v=v)
 
 	if comment.author_id != v.id: abort(403)

--- a/files/templates/component/comment/actions_desktop.html
+++ b/files/templates/component/comment/actions_desktop.html
@@ -19,7 +19,7 @@
 {% endif %}
 {% endif %}
 
-{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+{%- if v and v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 	{%- set show_approve = c.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 	{%- set show_remove = c.state_mod != StateMod.REMOVED -%}
 	<button id="remove-{{c.id}}" class="btn caction py-0 nobackground px-1 text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(false, {{c.id}}, true, 'remove-{{c.id}}', 'remove2-{{c.id}}', 'approve-{{c.id}}', 'approve2-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>

--- a/files/templates/component/comment/actions_desktop.html
+++ b/files/templates/component/comment/actions_desktop.html
@@ -19,10 +19,12 @@
 {% endif %}
 {% endif %}
 
-{% if v and v.admin_level >= 2 and c.state_mod == StateMod.FILTERED %}
-	<button class="btn" role="button" id="filter-approve" onclick="filter_new_comment_status({{ c.id }}, 'normal')"><span>Approve</span></button>
-	<button class="btn" role="button" id="filter-remove" onclick="filter_new_comment_status({{ c.id }}, 'removed')"><span>Remove</span></button>
-{% endif %}
+{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+	{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
+	{%- set show_remove = p.state_mod != StateMod.REMOVED -%}
+	<button id="remove-{{c.id}}" class="btn caction py-0 nobackground px-1 text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="removeCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
+	<button id="approve-{{c.id}}" class="btn caction py-0 nobackground px-1 text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="approveCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}');"><i class="fas fa-check"></i>Approve</a>
+{%- endif -%}
 
 {% if v %}
 	<button style="margin-top:0.2rem" class="btn caction py-0 nobackground px-1 text-muted" data-bs-toggle="dropdown" aria-expanded="false"><i class="fas fa-ellipsis-h fa-fw"></i></button>
@@ -42,16 +44,6 @@
 		{% if url != "" %}
 			<button id="unpin-{{c.id}}" class="dropdown-item list-inline-item {% if c.is_pinned %}d-md-block{% endif %} text-muted d-none text-info"  data-bs-dismiss="modal" data-bs-target="#actionsModal-{{c.id}}" onclick="post_toast3(this,'/un{{url}}/{{c.id}}','pin-{{c.id}}','unpin-{{c.id}}')"><i class="fas fa-thumbtack fa-rotate--45 text-info fa-fw"></i>Unpin</button>
 			<button id="pin-{{c.id}}" class="dropdown-item list-inline-item {% if not c.is_pinned %}d-md-block{% endif %} text-muted d-none text-info" data-bs-dismiss="modal" data-bs-target="#actionsModal-{{c.id}}" onclick="post_toast3(this,'/{{url}}/{{c.id}}','pin-{{c.id}}','unpin-{{c.id}}')"><i class="fas fa-thumbtack fa-rotate--45 text-info fa-fw"></i>Pin</button>
-		{% endif %}
-	{% endif %}
-
-	{% if v.admin_level >= 2 %}
-		{% if "/reported/" in request.path %}
-			<button class="dropdown-item list-inline-item text-success" onclick="approveCommentDesktop('{{c.id}}')"><i class="fas fa-check text-success fa-fw"></i>Approve</button>
-			<button class="dropdown-item list-inline-item text-danger" onclick="removeCommentDesktop('{{c.id}}')"><i class="fas fa-ban text-danger fa-fw"></i>Remove</button>
-		{% else %}
-			<button id="approve-{{c.id}}" class="dropdown-item list-inline-item d-none {% if c.state_mod != StateMod.VISIBLE %}d-md-block{% endif %} text-success" onclick="approveCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}')"><i class="fas fa-check text-success fa-fw"></i>Approve</button>
-			<button id="remove-{{c.id}}" class="dropdown-item list-inline-item d-none {% if c.state_mod != StateMod.REMOVED %}d-md-block{% endif %} text-danger" onclick="removeCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}')"><i class="fas fa-ban text-danger fa-fw"></i>Remove</button>
 		{% endif %}
 	{% endif %}
 

--- a/files/templates/component/comment/actions_desktop.html
+++ b/files/templates/component/comment/actions_desktop.html
@@ -20,8 +20,8 @@
 {% endif %}
 
 {%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
-	{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
-	{%- set show_remove = p.state_mod != StateMod.REMOVED -%}
+	{%- set show_approve = c.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
+	{%- set show_remove = c.state_mod != StateMod.REMOVED -%}
 	<button id="remove-{{c.id}}" class="btn caction py-0 nobackground px-1 text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="removeCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
 	<button id="approve-{{c.id}}" class="btn caction py-0 nobackground px-1 text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="approveCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}');"><i class="fas fa-check"></i>Approve</a>
 {%- endif -%}

--- a/files/templates/component/comment/actions_desktop.html
+++ b/files/templates/component/comment/actions_desktop.html
@@ -22,8 +22,8 @@
 {%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 	{%- set show_approve = c.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 	{%- set show_remove = c.state_mod != StateMod.REMOVED -%}
-	<button id="remove-{{c.id}}" class="btn caction py-0 nobackground px-1 text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="removeCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
-	<button id="approve-{{c.id}}" class="btn caction py-0 nobackground px-1 text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="approveCommentDesktop('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}');"><i class="fas fa-check"></i>Approve</a>
+	<button id="remove-{{c.id}}" class="btn caction py-0 nobackground px-1 text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(false, {{c.id}}, true, 'remove-{{c.id}}', 'remove2-{{c.id}}', 'approve-{{c.id}}', 'approve2-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
+	<button id="approve-{{c.id}}" class="btn caction py-0 nobackground px-1 text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(false, {{c.id}}, false, 'remove-{{c.id}}', 'remove2-{{c.id}}', 'approve-{{c.id}}', 'approve2-{{c.id}}');"><i class="fas fa-check"></i>Approve</a>
 {%- endif -%}
 
 {% if v %}

--- a/files/templates/component/comment/actions_mobile_admin.html
+++ b/files/templates/component/comment/actions_mobile_admin.html
@@ -28,8 +28,8 @@
 					{% endif %}
 
 					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
-						{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
-						{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
+						{%- set show_approve = c.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
+						{%- set show_remove = c.state_mod == StateMod.VISIBLE -%}
 						<a id="remove2-{{c.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="removeCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
 						<a id="approve2-{{c.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="approveCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}');"><i class="fas fa-check"></i>Approve</a>
 					{%- endif -%}

--- a/files/templates/component/comment/actions_mobile_admin.html
+++ b/files/templates/component/comment/actions_mobile_admin.html
@@ -27,13 +27,12 @@
 						<a id="unban2-{{c.id}}" class="{% if not c.author.is_banned %}d-none{% endif %} list-group-item text-success" role="button" onclick="post_toast2(this,'/unban_user/{{c.author_id}}','ban2-{{c.id}}','unban2-{{c.id}}')" data-bs-dismiss="modal"><i class="fas fa-user-minus fa-fw text-success mr-2"></i>Unban user</a>
 					{% endif %}
 
-					{% if "/reported/" in request.path %}
-						<a class="list-group-item text-danger" role="button" onclick="removeCommentMobile('{{c.id}}')" data-bs-dismiss="modal"><i class="fas fa-ban text-danger mr-2"></i>Remove</a>
-						<a class="list-group-item text-success" role="button" onclick="approveCommentMobile('{{c.id}}')" data-bs-dismiss="modal"><i class="fas fa-check text-success mr-2"></i>Approve</a>
-					{% else %}
-						<a id="remove2-{{c.id}}" class="{% if c.state_mod != StateMod.VISIBLE %}d-none{% endif %} list-group-item text-danger" role="button" onclick="removeCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}')" data-bs-dismiss="modal"><i class="fas fa-ban text-danger mr-2"></i>Remove</a>
-						<a id="approve2-{{c.id}}" class="{% if c.state_mod != StateMod.REMOVED %}d-none{% endif %} list-group-item text-success" role="button" onclick="approveCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}')" data-bs-dismiss="modal"><i class="fas fa-check text-success mr-2"></i>Approve</a>
-					{% endif %}
+					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+						{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
+						{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
+						<a id="remove2-{{c.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="removeCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
+						<a id="approve2-{{c.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="approveCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}');"><i class="fas fa-check"></i>Approve</a>
+					{%- endif -%}
 
 					{% if c.oauth_app %}
 						<a href="{{c.oauth_app.permalink}}/comments" class="list-group-item text-info"><i class="fas fa-code text-info mr-2"></i>API App</a>

--- a/files/templates/component/comment/actions_mobile_admin.html
+++ b/files/templates/component/comment/actions_mobile_admin.html
@@ -27,7 +27,7 @@
 						<a id="unban2-{{c.id}}" class="{% if not c.author.is_banned %}d-none{% endif %} list-group-item text-success" role="button" onclick="post_toast2(this,'/unban_user/{{c.author_id}}','ban2-{{c.id}}','unban2-{{c.id}}')" data-bs-dismiss="modal"><i class="fas fa-user-minus fa-fw text-success mr-2"></i>Unban user</a>
 					{% endif %}
 
-					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+					{%- if v and v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 						{%- set show_approve = c.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 						{%- set show_remove = c.state_mod == StateMod.VISIBLE -%}
 						<a id="remove2-{{c.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(false, {{c.id}}, true, 'remove-{{c.id}}', 'remove2-{{c.id}}', 'approve-{{c.id}}', 'approve2-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>

--- a/files/templates/component/comment/actions_mobile_admin.html
+++ b/files/templates/component/comment/actions_mobile_admin.html
@@ -30,8 +30,8 @@
 					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 						{%- set show_approve = c.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 						{%- set show_remove = c.state_mod == StateMod.VISIBLE -%}
-						<a id="remove2-{{c.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="removeCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
-						<a id="approve2-{{c.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="approveCommentMobile('{{c.id}}','approve2-{{c.id}}','remove2-{{c.id}}');"><i class="fas fa-check"></i>Approve</a>
+						<a id="remove2-{{c.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(false, {{c.id}}, true, 'remove-{{c.id}}', 'remove2-{{c.id}}', 'approve-{{c.id}}', 'approve2-{{c.id}}');"><i class="fas fa-ban"></i>Remove</a>
+						<a id="approve2-{{c.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(false, {{c.id}}, false, 'remove-{{c.id}}', 'remove2-{{c.id}}', 'approve-{{c.id}}', 'approve2-{{c.id}}');"></i>Approve</a>
 					{%- endif -%}
 
 					{% if c.oauth_app %}

--- a/files/templates/component/post/actions.html
+++ b/files/templates/component/post/actions.html
@@ -61,8 +61,8 @@
 			{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 				{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 				{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
-				<a id="remove-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>
-				<a id="approve-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check"></i>Approve</a>
+				<a id="remove-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{p.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>
+				<a id="approve-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(true, {{p.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check"></i>Approve</a>
 			{%- endif -%}
 
 			{% if v.admin_level >= 2 %}

--- a/files/templates/component/post/actions.html
+++ b/files/templates/component/post/actions.html
@@ -58,7 +58,7 @@
 				<a id="unclub-{{p.id}}" class="dropdown-item {% if not p.club %}d-none{% endif %} list-inline-item text-info" role="button" onclick="post_toast2(this,'/toggle_club/{{p.id}}','club-{{p.id}}','unclub-{{p.id}}')"><i class="fas fa-eye"></i>Unmark club</a>
 			{% endif %} #}
 
-			{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+			{%- if v and v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 				{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 				{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
 				<a id="remove-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{p.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>

--- a/files/templates/component/post/actions.html
+++ b/files/templates/component/post/actions.html
@@ -58,15 +58,14 @@
 				<a id="unclub-{{p.id}}" class="dropdown-item {% if not p.club %}d-none{% endif %} list-inline-item text-info" role="button" onclick="post_toast2(this,'/toggle_club/{{p.id}}','club-{{p.id}}','unclub-{{p.id}}')"><i class="fas fa-eye"></i>Unmark club</a>
 			{% endif %} #}
 
-			{% if v.admin_level > 1 %}
-				{% if "/reported/" in request.path %}
-					{% if v.id != p.author.id %}<a class="dropdown-item list-inline-item text-danger" role="button" onclick="post_toast(this,'/remove_post/{{p.id}}')"><i class="fas fa-ban"></i>Remove</a>{% endif %}
-					<a class="dropdown-item list-inline-item text-success" role="button" onclick="post_toast(this,'/unremove_post/{{p.id}}')"><i class="fas fa-check"></i>Approve</a>
-				{% else %}
-					{% if v.id != p.author.id %}<a id="remove-{{p.id}}" class="dropdown-item {% if p.state_mod == StateMod.REMOVED %}d-none{% endif %} list-inline-item text-danger" role="button" onclick="post_toast2(this,'/remove_post/{{p.id}}','remove-{{p.id}}','approve-{{p.id}}')"><i class="fas fa-ban"></i>Remove</a>{% endif %}
-					<a id="approve-{{p.id}}" class="dropdown-item {% if p.state_mod == StateMod.VISIBLE %}d-none{% endif %} list-inline-item text-success" role="button" onclick="post_toast2(this,'/unremove_post/{{p.id}}','remove-{{p.id}}','approve-{{p.id}}')"><i class="fas fa-check"></i>Approve</a>
-				{% endif %}
+			{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+				{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
+				{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
+				<a id="remove-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'removed');"><i class="fas fa-ban"></i>Remove</a>
+				<a id="approve-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'normal');"><i class="fas fa-check"></i>Approve</a>
+			{%- endif -%}
 
+			{% if v.admin_level >= 2 %}
 				{% if p.oauth_app %}
 					<a class="dropdown-item list-inline-item" href="{{p.oauth_app.permalink}}"><i class="fas fa-code"></i>API App</a>
 				{% endif %}

--- a/files/templates/component/post/actions.html
+++ b/files/templates/component/post/actions.html
@@ -61,8 +61,8 @@
 			{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 				{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 				{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
-				<a id="remove-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'removed');"><i class="fas fa-ban"></i>Remove</a>
-				<a id="approve-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'normal');"><i class="fas fa-check"></i>Approve</a>
+				<a id="remove-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>
+				<a id="approve-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check"></i>Approve</a>
 			{%- endif -%}
 
 			{% if v.admin_level >= 2 %}

--- a/files/templates/component/post/actions_admin_mobile.html
+++ b/files/templates/component/post/actions_admin_mobile.html
@@ -22,7 +22,7 @@
 					<button id="pin2-{{p.id}}" class="{% if p.stickied %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-left text-primary" role="button" onclick="post_toast2(this,'/sticky/{{p.id}}','pin2-{{p.id}}','unpin2-{{p.id}}')" data-bs-dismiss="modal"><i class="fas fa-thumbtack fa-rotate--45 text-center text-primary mr-3"></i>Pin</button>
 					<button id="unpin2-{{p.id}}" class="{% if not p.stickied %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-left text-primary" role="button" onclick="post_toast2(this,'/unsticky/{{p.id}}','pin2-{{p.id}}','unpin2-{{p.id}}')" data-bs-dismiss="modal"><i class="fas fa-thumbtack fa-rotate--45 text-center  text-primary mr-3"></i>Unpin</button>
 
-					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+					{%- if v and v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 						{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 						{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
 						<a id="remove2-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{p.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>

--- a/files/templates/component/post/actions_admin_mobile.html
+++ b/files/templates/component/post/actions_admin_mobile.html
@@ -25,8 +25,8 @@
 					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 						{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 						{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
-						<a id="remove2-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>
-						<a id="approve2-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check"></i>Approve</a>
+						<a id="remove2-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{p.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>
+						<a id="approve2-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(true, {{p.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check"></i>Approve</a>
 					{%- endif -%}
 
 					{% if p.oauth_app %}

--- a/files/templates/component/post/actions_admin_mobile.html
+++ b/files/templates/component/post/actions_admin_mobile.html
@@ -20,21 +20,14 @@
 					<button id="undistinguish2-{{p.id}}" class="{% if not p.distinguish_level %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-left text-primary" role="button" onclick="post_toast2(this,'/distinguish/{{p.id}}','distinguish2-{{p.id}}','undistinguish2-{{p.id}}')" data-bs-dismiss="modal"><i class="fas fa-crown text-center text-primary mr-3"></i>Undistinguish</button> #}
 
 					<button id="pin2-{{p.id}}" class="{% if p.stickied %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-left text-primary" role="button" onclick="post_toast2(this,'/sticky/{{p.id}}','pin2-{{p.id}}','unpin2-{{p.id}}')" data-bs-dismiss="modal"><i class="fas fa-thumbtack fa-rotate--45 text-center text-primary mr-3"></i>Pin</button>
-
 					<button id="unpin2-{{p.id}}" class="{% if not p.stickied %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-left text-primary" role="button" onclick="post_toast2(this,'/unsticky/{{p.id}}','pin2-{{p.id}}','unpin2-{{p.id}}')" data-bs-dismiss="modal"><i class="fas fa-thumbtack fa-rotate--45 text-center  text-primary mr-3"></i>Unpin</button>
 
-					{% if "/reported/" in request.path %}
-						<button class="nobackground btn btn-link btn-block btn-lg text-danger text-left" role="button" onclick="post_toast(this,'/remove_post/{{p.id}}')" data-bs-dismiss="modal"><i class="far fa-ban text-center mr-3"></i>Remove</button>
-						<button class="nobackground btn btn-link btn-block btn-lg text-success text-left" role="button" onclick="post_toast(this,'/unremove_post/{{p.id}}')" data-bs-dismiss="modal"><i class="far fa-check text-center mr-3"></i>Approve</button>
-					{% else %}
-						<button id="remove2-{{p.id}}" class="{% if p.state_mod == StateMod.REMOVED %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-danger text-left" role="button" onclick="post_toast2(this,'/remove_post/{{p.id}}','remove2-{{p.id}}','approve2-{{p.id}}')" data-bs-dismiss="modal"><i class="far fa-ban text-center mr-3"></i>Remove</button>
-						<button id="approve2-{{p.id}}" class="{% if p.state_mod == StateMod.VISIBLE %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-success text-left"  role="button" onclick="post_toast2(this,'/unremove_post/{{p.id}}','remove2-{{p.id}}','approve2-{{p.id}}')" data-bs-dismiss="modal"><i class="far fa-check text-center mr-3"></i>Approve</button>
-					{% endif %}
-
-					{% if v and v.admin_level >= 2 and p.state_mod == StateMod.FILTERED %}
-						<button id="mobile-filter-approve-{{p.id}}" class="nobackground btn btn-link btn-block btn-lg text-success text-left" role="button" onclick="filter_new_status({{p.id}}, 'normal')"><i class="far fa-check text-center mr-3"></i>Filter Approve</a>
-						<button id="mobile-filter-remove-{{p.id}}" class="nobackground btn btn-link btn-block btn-lg text-danger text-left" role="button" onclick="filter_new_status({{p.id}}, 'removed')"><i class="far fa-ban text-center mr-3"></i>Filter Remove</a>
-					{% endif %}
+					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
+						{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
+						{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
+						<a id="remove2-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'removed');"><i class="fas fa-ban"></i>Remove</a>
+						<a id="approve2-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'normal');"><i class="fas fa-check"></i>Approve</a>
+					{%- endif -%}
 
 					{% if p.oauth_app %}
 						<a href="{{p.oauth_app.permalink}}"><button class="nobackground btn btn-link btn-block btn-lg text-muted text-left"><i class="far fa-code text-center text-info mr-3"></i>API App</button></a>
@@ -47,7 +40,6 @@
 						<button id="ban2-{{p.id}}" data-bs-dismiss="modal" data-bs-toggle="modal" data-bs-target="#banModal" onclick="banModal('/post/{{p.id}}', '{{p.author.id}}', '{{p.author_name}}')" class="{% if p.author.is_suspended %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-danger text-left" role="button"><i class="fas fa-user-minus mr-3"></i>Ban user</button>
 						<button id="unban2-{{p.id}}" class="{% if not p.author.is_suspended %}d-none{% endif %} nobackground btn btn-link btn-block btn-lg text-success text-left" role="button" onclick="post_toast2(this,'/unban_user/{{p.author_id}}','ban2-{{p.id}}','unban2-{{p.id}}')" data-bs-dismiss="modal"><i class="fas fa-user-minus mr-3"></i>Unban user</button>
 					{% endif %}
-
 				</ul>
 			</div>
 		</div>

--- a/files/templates/component/post/actions_admin_mobile.html
+++ b/files/templates/component/post/actions_admin_mobile.html
@@ -25,8 +25,8 @@
 					{%- if v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 						{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 						{%- set show_remove = p.state_mod == StateMod.VISIBLE -%}
-						<a id="remove2-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'removed');"><i class="fas fa-ban"></i>Remove</a>
-						<a id="approve2-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="filter_new_status({{p.id}}, 'normal');"><i class="fas fa-check"></i>Approve</a>
+						<a id="remove2-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>
+						<a id="approve2-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" onclick="moderate(true, {{c.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check"></i>Approve</a>
 					{%- endif -%}
 
 					{% if p.oauth_app %}

--- a/migrations/versions/2023_07_22_14_37_20_a23fe2f1515c_rename_approve_mod_actions.py
+++ b/migrations/versions/2023_07_22_14_37_20_a23fe2f1515c_rename_approve_mod_actions.py
@@ -1,0 +1,25 @@
+"""Rename approve mod actions
+
+Revision ID: a23fe2f1515c
+Revises: 7ae4658467d7
+Create Date: 2023-07-22 14:37:20.485816+00:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a23fe2f1515c'
+down_revision = '7ae4658467d7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+	op.execute("UPDATE modactions SET kind='approve_post' WHERE kind='unremove_post';")
+	op.execute("UPDATE modactions SET kind='approve_comment' WHERE kind='unremove_comment';")
+
+
+def downgrade():
+	op.execute("UPDATE modactions SET kind='unremove_post' WHERE kind='approve_post';")
+	op.execute("UPDATE modactions SET kind='unremove_comment' WHERE kind='approve_comment';")


### PR DESCRIPTION
#120 added post and comment filtering, and #359 was fixed ultimately as the
result of #606. these say that `/admin/update_filter_status` should be the
way to update a post's visibility state.

unforunately, a lot of the UI was using the old routes, and worse still,
some actions such as removals and approvals weren't being logged with the
new filter state routes. this solves this issue. we do this:

* remove the old, deprecated, routes
* add logging to the new route
* rewire the UI to use the new route for all state transitions
* fixes some UI inconsistencies in the process (specifically around icons and what a specific button does)

fixes #635 
fixes #636 