### PR TITLE
fix duplicate `~new~` indicators being sent

### DIFF
--- a/files/assets/js/comments.js
+++ b/files/assets/js/comments.js
@@ -57,3 +57,21 @@ function expandMarkdown(t,id) {
 	if (val.innerHTML == 'View source') val.innerHTML = 'Hide source'
 	else val.innerHTML = 'View source'
 };
+
+function commentsAddUnreadIndicator(commentIds) {
+	commentIds.forEach(element => {
+		const commentOnly = document.getElementById(`comment-${element}-only`);
+		if (!commentOnly) { 
+			console.warn(`Couldn't find comment (comment ID ${element}) in page while attempting to add an unread indicator.`);
+			return;
+		}
+		if (commentOnly.classList.contains("unread")) return;
+		commentOnly.classList.add("unread");
+		const commentUserInfo = document.getElementById(`comment-${element}`)?.querySelector(".comment-user-info");
+		if (!commentUserInfo) {
+			console.warn(`Couldn't find comment user info (comment ID ${element}) in page while attempting to add an unread indicator.`);
+			return;
+		}
+		commentUserInfo.innerHTML += "<span class=\"new-indicator\">~new~</span>";
+	});
+}

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -201,6 +201,7 @@
 	<script src="{{ 'js/comments+submission_listing.js' | asset }}"></script>
 	<script src="{{ 'js/comments.js' | asset }}"></script>
 
+	{# See #}
 	<script>
 		{% if p and (not v or v.highlightcomments) %}
 			comments = JSON.parse(localStorage.getItem("comment-counts")) || {}
@@ -213,9 +214,8 @@
 				{% endfor %}
 			];
 
-			commentsToCheck = commentsToCheck.filter(comment => {
-				return comment[1] > lastCount.t
-			}).map(comment => comment[0]);
+			commentsToCheck = commentsToCheck.filter(comment => comment[1] > lastCount.t)
+			                                 .map(comment => comment[0]);
 
 			if (lastCount) commentsAddUnreadIndicator(commentsToCheck);
 		{% endif %}
@@ -259,9 +259,8 @@
 							{% endfor %}
 						];
 
-						commentsToCheck = commentsToCheck.filter(comment => {
-							return comment[1] > lastCount.t
-						}).map(comment => comment[0]);
+						commentsToCheck = commentsToCheck.filter(comment => comment[1] > lastCount.t)
+						                                 .map(comment => comment[0]);
 						
 						if (lastCount) commentsAddUnreadIndicator(commentsToCheck);
 					{% endif %}

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -205,19 +205,19 @@
 		{% if p and (not v or v.highlightcomments) %}
 			comments = JSON.parse(localStorage.getItem("comment-counts")) || {}
 			lastCount = comments['{{p.id}}']
-			if (lastCount)
-			{
-				{% for c in p.comments %}
+			var commentsToCheck = [
+				{% for c in p.comments -%}
 					{% if not (v and v.id==c.author_id) and not c.voted %}
-						if ({{c.created_utc*1000}} > lastCount.t) 
-						try {
-							document.getElementById("comment-{{c.id}}-only").classList.add('unread')
-							document.getElementById("comment-{{c.id}}").querySelector(".comment-user-info").innerHTML += "<span>~new~</span>";
-						}
-						catch(e) {}
+					[{{c.id}}, {{c.created_utc * 1000}}],
 					{% endif %}
 				{% endfor %}
-			}
+			];
+
+			commentsToCheck = commentsToCheck.filter(comment => {
+				return comment[1] > lastCount.t
+			}).map(comment => comment[0]);
+
+			if (lastCount) commentsAddUnreadIndicator(commentsToCheck);
 		{% endif %}
 
 		{% if p and not (request.values and ('context' in request.values)) %}
@@ -250,19 +250,20 @@
 					{% if p %}
 						comments = JSON.parse(localStorage.getItem("old-comment-counts")) || {}
 						lastCount = comments['{{p.id}}']
-						if (lastCount)
-						{
-							{% for c in p.comments %}
+
+						var commentsToCheck = [
+							{% for c in p.comments -%}
 								{% if not (v and v.id==c.author_id) and not c.voted %}
-									if ({{c.created_utc*1000}} > lastCount.t) 
-									try {
-										document.getElementById("comment-{{c.id}}-only").classList.add('unread')
-										document.getElementById("comment-{{c.id}}").querySelector(".comment-user-info").innerHTML += "<span>~new~</span>";
-									}
-									catch(e) {}
+								[{{c.id}}, {{c.created_utc * 1000}}],
 								{% endif %}
 							{% endfor %}
-						}
+						];
+
+						commentsToCheck = commentsToCheck.filter(comment => {
+							return comment[1] > lastCount.t
+						}).map(comment => comment[0]);
+						
+						if (lastCount) commentsAddUnreadIndicator(commentsToCheck);
 					{% endif %}
 				}
 				btn.disabled = false;

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -201,7 +201,7 @@
 	<script src="{{ 'js/comments+submission_listing.js' | asset }}"></script>
 	<script src="{{ 'js/comments.js' | asset }}"></script>
 
-	{# See #}
+	{# See https://github.com/themotte/rDrama/pull/642#issuecomment-1646649781 for info on this section of the code #}
 	<script>
 		{% if p and (not v or v.highlightcomments) %}
 			comments = JSON.parse(localStorage.getItem("comment-counts")) || {}

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -208,9 +208,9 @@
 			lastCount = comments['{{p.id}}']
 			var commentsToCheck = [
 				{% for c in p.comments -%}
-					{% if not (v and v.id==c.author_id) and not c.voted %}
+					{%- if not (v and v.id==c.author_id) and not c.voted %}
 					[{{c.id}}, {{c.created_utc * 1000}}],
-					{% endif %}
+					{%- endif -%}
 				{% endfor %}
 			];
 
@@ -253,9 +253,9 @@
 
 						var commentsToCheck = [
 							{% for c in p.comments -%}
-								{% if not (v and v.id==c.author_id) and not c.voted %}
+								{%- if not (v and v.id==c.author_id) and not c.voted %}
 								[{{c.id}}, {{c.created_utc * 1000}}],
-								{% endif %}
+								{%- endif -%}
 							{% endfor %}
 						];
 

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -494,7 +494,7 @@
 						{% for c in p.comments -%}
 							{% if not (v and v.id==c.author_id) and not c.voted %}
 							[{{c.id}}, {{c.created_utc * 1000}}],
-							{% endif %}
+							{%- endif -%}
 						{% endfor %}
 					];
 

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -489,19 +489,20 @@
 
 					comments = JSON.parse(localStorage.getItem("old-comment-counts")) || {}
 					lastCount = comments['{{p.id}}']
-					if (lastCount)
-					{
-						{% for c in p.comments %}
+
+					var commentsToCheck = [
+						{% for c in p.comments -%}
 							{% if not (v and v.id==c.author_id) and not c.voted %}
-								if ({{c.created_utc*1000}} > lastCount.t) 
-								try {
-									document.getElementById("comment-{{c.id}}-only").classList.add('unread')
-									document.getElementById("comment-{{c.id}}").querySelector(".comment-user-info").innerHTML += "<span>~new~</span>";
-								}
-								catch(e) {}
+							[{{c.id}}, {{c.created_utc * 1000}}],
 							{% endif %}
 						{% endfor %}
-					}
+					];
+
+					commentsToCheck = commentsToCheck.filter(comment => {
+						return comment[1] > lastCount.t
+					}).map(comment => comment[0]);
+					
+					if (lastCount) commentsAddUnreadIndicator(commentsToCheck);
 
 					collapsedCommentStorageApply();
 				}

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -498,9 +498,8 @@
 						{% endfor %}
 					];
 
-					commentsToCheck = commentsToCheck.filter(comment => {
-						return comment[1] > lastCount.t
-					}).map(comment => comment[0]);
+					commentsToCheck = commentsToCheck.filter(comment => comment[1] > lastCount.t)
+					                                 .map(comment => comment[0]);
 					
 					if (lastCount) commentsAddUnreadIndicator(commentsToCheck);
 


### PR DESCRIPTION
consequently, we also make the JS we're generating about 7% the size it was before (a standard culture war thread would clock in about 1 MB of JS, we get this down to approximately 70 KB). fixes #608 