### PR TITLE
fix header dropdown menu side-scroll on desktop

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -5134,7 +5134,7 @@ th, td {
 }
 
 #account-menu-header, #account-menu {
-	min-width: 10em;
+	min-width: 13em;
 }
 
 .navigation-secondary-link {


### PR DESCRIPTION
This is just an update on TLSM's pull https://github.com/themotte/rDrama/pull/187, accommodating for the longer menu item introduced after that fix: "Support The Motte".

After min-width update:
![image](https://github.com/themotte/rDrama/assets/33473788/f396b604-d973-4956-a2a0-5868403c2c2c)

