### PR TITLE
JS: optional chaining seems to break older browsers

### DIFF
--- a/files/assets/js/comments.js
+++ b/files/assets/js/comments.js
@@ -67,7 +67,12 @@ function commentsAddUnreadIndicator(commentIds) {
 		}
 		if (commentOnly.classList.contains("unread")) return;
 		commentOnly.classList.add("unread");
-		const commentUserInfo = document.getElementById(`comment-${element}`)?.querySelector(".comment-user-info");
+		const commentElement = document.getElementById(`comment-${element}`);
+		if (!commentElement) {
+			console.warn(`Couldn't find comment (ID ${element}) in page while attempting to add an unread indicator.`);
+			return;
+		}
+		const commentUserInfo = commentElement.querySelector(".comment-user-info");
 		if (!commentUserInfo) {
 			console.warn(`Couldn't find comment user info (comment ID ${element}) in page while attempting to add an unread indicator.`);
 			return;


### PR DESCRIPTION
https://caniuse.com/mdn-javascript_operators_optional_chaining

it seems to be less supported on mobile devices then I'd expect so here's a justification for it i guess

reported here: https://www.themotte.org/post/563/-/122837