### PR TITLE
Move CSP from HTML to headers

### DIFF
--- a/files/routes/allroutes.py
+++ b/files/routes/allroutes.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import json
 import sys
 import time
+from typing import TYPE_CHECKING
 
 from flask import abort, g, request
 
 from files.__main__ import app, db_session, limiter
 
+if TYPE_CHECKING:
+	from flask.wrappers import Response
 
 @app.before_request
 def before_request():
@@ -45,7 +50,13 @@ def teardown_request(error):
 	sys.stdout.flush()
 
 @app.after_request
-def after_request(response):
+def after_request(response: Response):
+	response.headers.add("Content-Security-Policy", (
+		"script-src 'self' 'unsafe-inline';"
+		" connect-src 'self' *.google-analytics.com *.analytics.google.com;"
+		" object-src 'none';"
+		" img-src 'self' *.google-analytics.com *.analytics.google.com"
+	))
 	response.headers.add("Strict-Transport-Security", "max-age=31536000")
 	response.headers.add("X-Frame-Options", "deny")
 	return response

--- a/files/templates/chat.html
+++ b/files/templates/chat.html
@@ -1,16 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	{% include "analytics.html" %}
-	
-	<meta name="description" content="{{config('DESCRIPTION')}}">
-	{% include "csp.html" %}
-
 	<meta charset="utf-8">
+	{% include "analytics.html" %}
+	<meta name="description" content="{{config('DESCRIPTION')}}">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-	<meta name="author" content="">
-
 	<link id="favicon" rel="icon" type="image/png" href="{{ ('images/'~SITE_ID~'/icon.webp') | asset }}">
 
 	<title>Chat</title>

--- a/files/templates/csp.html
+++ b/files/templates/csp.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; connect-src 'self' *.google-analytics.com *.analytics.google.com; object-src 'none'; img-src 'self' *.google-analytics.com *.analytics.google.com">

--- a/files/templates/default.html
+++ b/files/templates/default.html
@@ -3,11 +3,8 @@
 <html lang="en">
 <head>
 	{% include "analytics.html" %}
-	
 	<link rel="alternate" type="application/rss+xml" title="The Motte RSS" href="/rss">
 	<meta name="description" content="{{config('DESCRIPTION')}}">
-	{% include "csp.html" %}
-
 	<script src="{{ 'js/bootstrap.js' | asset }}"></script>
 	<script src="{{ 'js/micromodal.js' | asset }}"></script>
 	{% if v %}

--- a/files/templates/login/authforms.html
+++ b/files/templates/login/authforms.html
@@ -3,7 +3,6 @@
 	<head>
 		<meta charset="utf-8">
 		{% include "analytics.html" %}
-		{% include "csp.html" %}
 		<meta name="description" content="{{config('DESCRIPTION')}}">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		<title>{% block pagetitle %}{{SITE_TITLE}}{% endblock %}</title>

--- a/files/templates/settings.html
+++ b/files/templates/settings.html
@@ -2,17 +2,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	{% include "analytics.html" %}
 
 	<meta name="description" content="{{config('DESCRIPTION')}}">
-	{% include "csp.html" %}
-
 	<script src="{{ 'js/bootstrap.js' | asset }}"></script>
 
-	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-	<meta name="author" content="">
 
 	<link rel="icon" type="image/png" href="{{ ('images/'~SITE_ID~'/icon.webp') | asset }}">
 

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -2,19 +2,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<meta charset="utf-8">
 	{% include "analytics.html" %}
-	
 	<meta name="description" content="{{config('DESCRIPTION')}}">
-	{% include "csp.html" %}
-
 		<script src="{{ 'js/bootstrap.js' | asset }}"></script>
-
-		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
 		<meta name="author" content="">
 		<link rel="icon" type="image/png" href="{{ ('images/'~SITE_ID~'/icon.webp') | asset }}">
-
 		{% block title %}
 		<title>Create a post - {{SITE_TITLE}}</title>
 		{% endblock %}


### PR DESCRIPTION
Standards recommend we use HTTP headers for our CSP. Let's do that.