### PR TITLE
Fix typo in reply container id

### DIFF
--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -36,7 +36,7 @@
 						{% endif %}
 					</div>
 					{% if replies and level >= RENDER_DEPTH_LIMIT -%}
-						<div id="morecomment-{{c.id}}" class="{% if is_notification_page %}d-md-none {% endif %}mt-2 more-comments">
+						<div id="morecomments-{{c.id}}" class="{% if is_notification_page %}d-md-none {% endif %}mt-2 more-comments">
 							{% if not is_notification_page %}<button id="btn-{{c.id}}" class="d-none d-md-block btn btn-primary" onclick="morecomments('{{c.id}}')">More comments ({{c.descendant_count}})</button>{% endif %}
 							<a {% if not is_notification_page %}class="d-md-none" {% endif %}href="{{c.morecomments}}">More comments <i class="fas fa-long-arrow-right ml-1"></i></a>
 						</div>


### PR DESCRIPTION
[This](https://www.themotte.org/post/765/culture-war-roundup-for-the-week/163527?context=8#context) bug must have the same root cause as #594, i.e. #714.  The element id is subtly wrong in one place, which causes the callback to [go boom](https://github.com/gldrk/rDrama/blob/a856dcbf3b72a3633482ce8041927085763b741d/files/templates/comments.html#L238).