### PR TITLE
Formatting button improvements

### DIFF
--- a/files/assets/js/formatting.js
+++ b/files/assets/js/formatting.js
@@ -1,57 +1,55 @@
-
-function makeBold(form) {
-	var text = document.getElementById(form);
-	var startIndex = text.selectionStart,
-	endIndex = text.selectionEnd;
-	var selectedText = text.value.substring(startIndex, endIndex);
-
-	var format = '**'
-
-	if (selectedText.includes('**')) {
-		text.value = selectedText.replace(/\*/g, '');
-	}
-	else if (selectedText.length == 0) {
-		text.value = text.value.substring(0, startIndex) + selectedText + text.value.substring(endIndex);
-	}
-	else {
-		text.value = text.value.substring(0, startIndex) + format + selectedText + format + text.value.substring(endIndex);
-	}
-}
-
-function makeItalics(form) {
-	var text = document.getElementById(form);
-	var startIndex = text.selectionStart,
-	endIndex = text.selectionEnd;
-	var selectedText = text.value.substring(startIndex, endIndex);
-
-	var format = '*'
-
-	if (selectedText.includes('*')) {
-		text.value = selectedText.replace(/\*/g, '');
-	}
-	else if (selectedText.length == 0) {
-		text.value = text.value.substring(0, startIndex) + selectedText + text.value.substring(endIndex);
-	}
-	else {
-		text.value = text.value.substring(0, startIndex) + format + selectedText + format + text.value.substring(endIndex);
-	}
-}
-
-function makeQuote(form) {
-	var text = document.getElementById(form);
-	var startIndex = text.selectionStart,
-	endIndex = text.selectionEnd;
-	var selectedText = text.value.substring(startIndex, endIndex);
-
-	var format = '>'
-
-	if (selectedText.includes('>')) {
-		text.value = text.value.substring(0, startIndex) + selectedText.replace(/\>/g, '') + text.value.substring(endIndex);
-	}
-	else if (selectedText.length == 0) {
-		text.value = text.value.substring(0, startIndex) + selectedText + text.value.substring(endIndex);
-	}
-	else {
-		text.value = text.value.substring(0, startIndex) + format + selectedText + text.value.substring(endIndex);
-	}
-}
+(function() {
+	var event = InputEvent
+		? function(type, attrs) {
+			return new InputEvent(type, attrs);
+		}
+		: function(type) {
+			e = document.createEvent('event');
+			e.initEvent(type, false, false);
+			return e;
+		};
+	var escape = function(str) {
+		return str.replace(/./g, '[$&]').replace(/[\\^]|]]/g, '\\$&');
+	};
+	var wrap = function(cb) {
+		return function(id) {
+			var form = document.getElementById(id);
+			if (cb(form)) {
+				var e = event('input', { inputType: 'insertReplacementText' });
+				form.dispatchEvent(e);
+			}
+		}
+	};
+	var select = function(cb) {
+		return function(form) {
+			var begin = form.selectionStart, end = form.selectionEnd;
+			if (begin == end)
+				return false;
+			form.value = form.value.substring(0, begin)
+				+ cb(form.value.substring(begin, end))
+				+ form.value.substring(end);
+			return true;
+		};
+	};
+	var enclose = function(mark) {
+		var re = new RegExp(escape(mark) + '(\\S.*?\\S|\\S)' + escape(mark), 'g');
+		return select(function(selection) {
+			var replacement = selection.replace(re, '$1');
+			if (replacement.length == selection.length)
+				replacement = mark + replacement + mark;
+			return replacement;
+		});
+	};
+	var quote = select(function(selection) {
+		var lines = selection.split('\n');
+		if (lines.some(function(line) { return /^\s*[^\s>]/.test(line) }))
+			return '>' + lines.join('\n>');
+		else
+			return lines.map(function(line) {
+				return line.substring(line.indexOf('>') + 1);
+			}).join('\n');
+	});
+	makeItalics = wrap(enclose('*'));
+	makeBold = wrap(enclose('**'));
+	makeQuote = wrap(quote);
+})()

--- a/files/assets/js/formatting.js
+++ b/files/assets/js/formatting.js
@@ -32,11 +32,13 @@
 		};
 	};
 	var enclose = function(mark) {
-		var re = new RegExp(escape(mark) + '(\\S.*?\\S|\\S)' + escape(mark), 'g');
+		var re = new RegExp(escape(mark) + '(\\S[^]*?\\S|\\S)' + escape(mark), 'g');
 		return select(function(selection) {
 			var replacement = selection.replace(re, '$1');
 			if (replacement.length == selection.length)
-				replacement = mark + replacement + mark;
+				replacement = replacement.replace(/\S[^]*\S|\S/, function (str) {
+					return mark + str + mark;
+				});
 			return replacement;
 		});
 	};

--- a/files/assets/js/formatting.js
+++ b/files/assets/js/formatting.js
@@ -32,10 +32,17 @@
 		};
 	};
 	var enclose = function(mark) {
-		var re = new RegExp(escape(mark) + '(\\S[^]*?\\S|\\S)' + escape(mark), 'g');
+		var re = (function() {
+			var pat = escape(mark);
+			return new RegExp(pat + '(\\S([^](?!\\s' + pat + '\\S))*?\\S|\\S)' + pat, 'g');
+		})();
 		return select(function(selection) {
 			return selection.replace(/[^]*?(?=\n{2,})|[^]*/g, function(selection) {
 				var replacement = selection.replace(re, '$1');
+				for (var old = Infinity;
+				     replacement.length < old;
+				     replacement = replacement.replace(re, '$1'))
+					old = replacement.length;
 				if (replacement.length == selection.length)
 					replacement = replacement.replace(/\S[^]*\S|\S/, function (str) {
 						return mark + str + mark;

--- a/files/assets/js/formatting.js
+++ b/files/assets/js/formatting.js
@@ -34,12 +34,14 @@
 	var enclose = function(mark) {
 		var re = new RegExp(escape(mark) + '(\\S[^]*?\\S|\\S)' + escape(mark), 'g');
 		return select(function(selection) {
-			var replacement = selection.replace(re, '$1');
-			if (replacement.length == selection.length)
-				replacement = replacement.replace(/\S[^]*\S|\S/, function (str) {
-					return mark + str + mark;
-				});
-			return replacement;
+			return selection.replace(/[^]*?(?=\n{2,})|[^]*/g, function(selection) {
+				var replacement = selection.replace(re, '$1');
+				if (replacement.length == selection.length)
+					replacement = replacement.replace(/\S[^]*\S|\S/, function (str) {
+						return mark + str + mark;
+					});
+				return replacement;
+			});
 		});
 	};
 	var quote = select(function(selection) {

--- a/files/assets/js/marked.custom.js
+++ b/files/assets/js/marked.custom.js
@@ -60,7 +60,7 @@ marked.use({
 function markdown(first, second) {
 	var input = document.getElementById(first);
 	var dest = document.getElementById(second);
-	if(dest && input && input.value.trim() !== ''){
+	if(dest && input){
 		for (var i = 0; i < dest.children.length; i++) {
 			dest.removeChild(dest.children[i]);
 		}


### PR DESCRIPTION
Currently, the comment preview is not updated when the text is changed using the formatting buttons.  One has to type something on the keyboard in order to see the change.  Another nuisance is that when there are no characters left in the text area, the preview retains its old state.  This PR makes both cases show the expected behavior.

It also slightly adjusts the buttons’ implementation, so that e.g. ‘Quote’ won’t remove innocuous `>` characters in the middle of lines.  Quoting now also handles multiple paragraphs and adds one level of quoting whenever at least one unquoted line is selected, which should make it easier to work with nested quotations.