### PR TITLE
Fix tooltips on Edited time.

### DIFF
--- a/files/templates/component/comment/user_info.html
+++ b/files/templates/component/comment/user_info.html
@@ -59,6 +59,6 @@
 	{% endif %}
 	
 	{% if c.edited_utc %}
-	<span class="time-edited" id="time-edit-{{c.id}}" onmouseover="timestamp('time-edit-{{c.id}}','{{c.edited_utc}}')"><span>&#183;</span> <span class="font-italic">Edited {{c.edited_string}}</span></span>
+		<span class="time-edited" id="time-edit-{{c.id}}" onmouseover="timestamp('time-edit-{{c.id}}','{{c.edited_utc}}')" data-bs-toggle="tooltip" data-bs-placement="bottom"><span>&#183;</span> <span class="font-italic">Edited {{c.edited_string}}</span></span>
 	{% endif %}
 </div>


### PR DESCRIPTION
I noticed that the tooltip showing the full timestamp does not work on the "Edited 1d ago" text (whereas it does on the regular "1d ago" posting time).  It appears this is because `data-bs-*` attributes are needed for Bootstrap to bind the tooltip event to an element, and they are missing for this one.  So this PR should fix this.