### PR TITLE
Fix: Hyperscroll bug caused by what seems like an unnecessary scroll-…

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -4926,9 +4926,6 @@ toast {
 	}
 }
 
-html {
-	scroll-padding-top: 100px;
-}
 .comment-anchor::before {
 	content: '';
 	display: block;


### PR DESCRIPTION
…padding-top (see: https://bugzilla.mozilla.org/show_bug.cgi?id=1960218 https://tildes.net/~tech/1loi/highlighting_text_in_wikipedia_scrolls_up_too_fast https://www.reddit.com/r/wikipedia/comments/1j66yvq/annoying_automatic_scrolling_when_highlighting/