### PR TITLE
Fix blockquote CSS

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -3650,7 +3650,7 @@ small, .small {
 	padding-bottom: 5px !important;
 	max-width: var(--text-width, 60em);
 }
-.comment .comment-body .comment-text p:last-child {
+.comment .comment-body .comment-text>p:last-child {
 	margin-bottom: 0;
 }
 .modal .comment-actions .list-group-item {
@@ -4537,7 +4537,6 @@ blockquote + p {
 	margin-top: 1rem;
 }
 blockquote p {
-	margin-bottom: 0;
 	padding-bottom: 0.7rem;
 	padding-top: 0.7rem;
 }

--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -4536,10 +4536,6 @@ blockquote + blockquote, blockquote:last-child {
 blockquote + p {
 	margin-top: 1rem;
 }
-blockquote p {
-	padding-bottom: 0.7rem;
-	padding-top: 0.7rem;
-}
 @media (min-width: 576px) {
 	.modal-dialog {
 		max-width: 50% !important;


### PR DESCRIPTION
The existing CSS makes it impossible to differentiate between two adjacent blockquote elements.