### PR TITLE
reduce likelihood of accidental top-level posts

### DIFF
--- a/files/routes/comments.py
+++ b/files/routes/comments.py
@@ -101,7 +101,7 @@ def post_pid_comment_cid(cid, pid=None, anything=None, v=None):
 	else: 
 		if post.state_mod != StateMod.VISIBLE and not (v and (v.admin_level >= 2 or post.author_id == v.id)): template = "submission_banned.html"
 		else: template = "submission.html"
-		return render_template(template, v=v, p=post, sort=sort, comment_info=comment_info, render_replies=True)
+		return render_template(template, v=v, p=post, sort=sort, comment_info=comment_info, render_replies=True, cid=cid)
 
 @app.post("/comment")
 @limiter.limit("1/second;20/minute;200/hour;1000/day")

--- a/files/templates/component/comment/replybox_comment.html
+++ b/files/templates/component/comment/replybox_comment.html
@@ -20,10 +20,10 @@
 					<input autocomplete="off" id="file-upload-reply-{{c.fullname}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-reply-{{c.fullname}}','file-upload-reply-{{c.fullname}}')" hidden>
 				</label>
 			</div>
-			<a id="save-reply-to-{{c.fullname}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="post_comment('{{c.fullname}}', '{{c.post.id}}', {{level}})"role="button">Comment</a>
+			<a id="save-reply-to-{{c.fullname}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="post_comment('{{c.fullname}}', '{{c.post.id}}', {{level}})"role="button">Reply</a>
 			<a role="button" onclick="document.getElementById('reply-to-{{c.id}}').classList.add('d-none')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 
 		</form>
-		<div id="reply-edit-{{c.id}}" class="preview mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>
+		<div id="reply-edit-{{c.id}}" class="preview mb-3 mt-5"><p class="preview-msg">Reply preview</p></div>
 		<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
 	</div>
 </div>

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -412,6 +412,7 @@
 			{{sorting_time.sort_dropdown(sort, none, SORTS_COMMENTS)}}
 		</div>
 
+    {% if cid %}
 	{% if v %}
 		<div id="comment-form-space-{{p.fullname}}" class="comment-write mb-3">
 			<form id="reply-to-{{p.fullname}}" action="/comment" method="post">
@@ -455,6 +456,7 @@
 			</div>
 		</div>
 	{% endif %}
+    {% endif %}
 
 	{% include "volunteer_teaser.html" %}
 


### PR DESCRIPTION
this is done by making two changes:
1. the button for making a reply is changed from "Comment" to "Reply" (the button for making a top-level comment is still "Comment"; this could be changed to "Top level comment" or something similar for even more clarity, but this might be too verbose)
2. the textbox for making a top-level comment is removed when the user is looking at a comment instead of the full post; I think this is the larger and more important change