### PR TITLE
Fix timestamp tooltip on unread comments.

### DIFF
--- a/files/assets/js/comments.js
+++ b/files/assets/js/comments.js
@@ -47,13 +47,13 @@ function collapse_comment(id, element) {
 };
 
 function expandMarkdown(t,id) {
-	let ta = document.getElementById('markdown-'+id);
+	const ta = document.getElementById('markdown-'+id);
 	ta.classList.toggle('d-none');
 	autoExpand(ta);
 	document.getElementsByClassName('text-expand-icon-'+id)[0].classList.toggle('fa-expand-alt');
 	document.getElementsByClassName('text-expand-icon-'+id)[0].classList.toggle('fa-compress-alt');
 
-	let val = t.getElementsByTagName('span')[0]
+	const val = t.getElementsByTagName('span')[0]
 	if (val.innerHTML == 'View source') val.innerHTML = 'Hide source'
 	else val.innerHTML = 'View source'
 };
@@ -62,21 +62,16 @@ function commentsAddUnreadIndicator(commentIds) {
 	commentIds.forEach(element => {
 		const commentOnly = document.getElementById(`comment-${element}-only`);
 		if (!commentOnly) { 
-			console.warn(`Couldn't find comment (comment ID ${element}) in page while attempting to add an unread indicator.`);
+			// Comment not visible
 			return;
 		}
 		if (commentOnly.classList.contains("unread")) return;
 		commentOnly.classList.add("unread");
-		const commentElement = document.getElementById(`comment-${element}`);
-		if (!commentElement) {
-			console.warn(`Couldn't find comment (ID ${element}) in page while attempting to add an unread indicator.`);
-			return;
-		}
-		const commentUserInfo = commentElement.querySelector(".comment-user-info");
+		const commentUserInfo = document.querySelector(`#comment-${element} .comment-user-info`);
 		if (!commentUserInfo) {
 			console.warn(`Couldn't find comment user info (comment ID ${element}) in page while attempting to add an unread indicator.`);
 			return;
 		}
-		commentUserInfo.innerHTML += "<span class=\"new-indicator\">~new~</span>";
+		commentUserInfo.insertAdjacentHTML('beforeend', '<span class="new-indicator">~new~</span>');
 	});
 }


### PR DESCRIPTION
On comments that are marked as `~new~` ("unread"), I notice that the tooltips on the timestamps do not show up.

The culprit is the use of `.innerHTML +=` to add the indicator to the node.  This serializes the HTML of all the element's content, adds to it, and then parses it to replace with new nodes.  This destroys any events that were attached to the original nodes, which is generally bad practice, and in this case results in the above bug.

This PR fixes:

*  The `.innerHTML +=` is replaced with `.insertAdjacentHTML()`, which adds to the element's content rather than replacing it.
*  I checked the codebase for any other uses of this idiom and did not find any.

Other small changes, hopefully not controversial:

*  If unread comments are not visible (e.g., due to depth), the console is spammed with messages about how the comment can't be found.  This seem useless, even for debugging, so I removed it.
*  There is a two-step `getElementById()` followed by `querySelector()`, with each checked.  This can be easily simplified to a single `.querySelector()`.
*  I replaced some `let`s in the previous function which should be `const`.