### PR TITLE
fix display bug on mobile

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -3611,6 +3611,7 @@ small, .small {
 }
 .comment-body {
 	grid-area: comment-body;
+	height: fit-content;
 }
 #notifications .comment, #userpage .comment {
 	margin-top: 0.25rem;


### PR DESCRIPTION
Fix problem described here: https://www.themotte.org/post/3392/friday-fun-thread-for-november-28/387759?context=8#context

https://i.ibb.co/fzcJPRSn/IMG-20251129-102906.jpg

So I'm not exactly sure what's causing the issue, some mix of flexbox and grid rules is incorrect. `#comment-{id}-only` divs are being rendered as larger than `.comment-body` divs when a user views their own comments. 

Chrome has built in AI assistance and while asking it to look into the problem it started it's response with "This is interesting."

Anyways `height: fit-content;` shouldn't cause any problems elsewhere. 