### PR TITLE
Fix nonsensical CSS

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -5119,7 +5119,7 @@ th, td {
 .text-small-mobile {
 	font-size: min(3vw,14px) !important;
 }
-.text-white, th a {
+.text-white {
 	color: #fff !important;
 }
 @media (max-width: 350px) {


### PR DESCRIPTION
There is absolutely no reason for a link inside a table header to be made white rather than the default color.