### PR TITLE
fix: remove 'Install the Webapp' popup (#671)

### DIFF
--- a/files/routes/static.py
+++ b/files/routes/static.py
@@ -438,8 +438,3 @@ def settings_security(v):
 						   v=v,
 						   mfa_secret=pyotp.random_base32() if not v.mfa_secret else None
 						   )
-
-@app.post("/dismiss_mobile_tip")
-def dismiss_mobile_tip():
-	session["tooltip_last_dismissed"] = int(time.time())
-	return "", 204

--- a/files/templates/home.html
+++ b/files/templates/home.html
@@ -113,43 +113,5 @@
 	</script>
 {% endif %}
 
-{% if request.path in ('/','/logged_out') and g.timestamp > session.get('tooltip_last_dismissed',0)+60*60*24*30 and not g.webview %}
-	<style>
-		.beg-icon {
-			color: #919191;
-			float: left;
-			font-size: 10px;
-			margin-top: 0.25rem;
-			margin-right: 0.25rem;
-		}
-	</style>
-
-	<div id="mobile-prompt-container" class="fixed-top">
-		<div id="mobile-prompt" href="javascript:void(0)" data-bs-toggle="tooltip" data-bs-container="#mobile-prompt-container" data-bs-placement="top" data-bs-trigger="click" data-bs-html="true" data-bs-original-title="<i class='beg-icon fas fa-x'></i>Install the {{SITE_TITLE}} webapp by saving this page to your home screen!"></div>
-	</div>
-
-	<script>
-		if (!("standalone" in window.navigator) && !(window.navigator.standalone)) {
-			if (window.innerWidth <= 737) {
-				const tt = bootstrap.Tooltip.getOrCreateInstance(document.getElementById('mobile-prompt'))
-				tt.show()
-				document.getElementsByClassName('tooltip')[0].onclick = function(event){
-					tt.hide()
-					var xhr = new XMLHttpRequest();
-					xhr.withCredentials=true;
-					xhr.open("POST", '/dismiss_mobile_tip', true);
-					xhr.send();
-				}
-			}
-		} 
-	</script>
-
-	<style>
-		#mobile-prompt + .bs-tooltip-bottom {
-			transform: None !important;
-			inset: 0px 0px auto auto !important;
-		}
-	</style>
-{% endif %}
 
 {% endblock %}

--- a/files/tests/test_static.py
+++ b/files/tests/test_static.py
@@ -269,15 +269,3 @@ def test_send_admin_route():
 	# Should send message or return error
 	assert response.status_code in [200, 302, 400, 403]
 
-
-def test_dismiss_mobile_tip_route():
-	"""Test POST /dismiss_mobile_tip route"""
-	from . import util
-	client, user = util_accounts.create_test_client_and_user("mobile-user")
-
-	response, _ = util.post_with_formkey(
-		client, "/dismiss_mobile_tip",
-		data={}
-	)
-	# Should dismiss tip (returns 204 No Content on success)
-	assert response.status_code in [200, 204, 302, 400]

--- a/files/tests/test_webapp_popup_removed.py
+++ b/files/tests/test_webapp_popup_removed.py
@@ -1,0 +1,47 @@
+"""Tests verifying the 'Install the Webapp' popup has been removed (#671).
+
+The popup was removed because it covered the notification bell on mobile
+and provided questionable value. These tests verify:
+1. The homepage no longer contains popup markup
+2. The dismiss_mobile_tip route no longer exists
+"""
+from . import util_accounts
+from . import util
+
+
+def test_homepage_no_mobile_prompt():
+	"""Test that the homepage does not contain the mobile-prompt popup"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert "mobile-prompt" not in response.text
+
+
+def test_homepage_no_mobile_prompt_logged_in():
+	"""Test that the homepage does not contain the mobile-prompt popup when logged in"""
+	client, user = util_accounts.create_test_client_and_user()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert "mobile-prompt" not in response.text
+
+
+def test_homepage_no_install_webapp_text():
+	"""Test that the homepage does not contain 'Install the' webapp text"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert "Install the" not in response.text
+
+
+def test_dismiss_mobile_tip_route_removed():
+	"""Test that POST /dismiss_mobile_tip route no longer exists"""
+	client, user = util_accounts.create_test_client_and_user()
+
+	response, _ = util.post_with_formkey(
+		client, "/dismiss_mobile_tip",
+		data={}
+	)
+	assert response.status_code == 404


### PR DESCRIPTION
## Summary

Fixes #671 -- removes the "Install the Webapp" nagware popup that appeared on mobile.

The popup covered the notification bell and top-right controls on mobile. Per discussion on the issue, multiple collaborators agreed the popup should be removed rather than fixed.

### Changes
- **`templates/home.html`**: Removed the mobile-prompt container, tooltip initialization JS, and associated CSS (~38 lines).
- **`routes/static.py`**: Removed `POST /dismiss_mobile_tip` route that stored dismissal timestamp in session.
- **`tests/test_static.py`**: Removed `test_dismiss_mobile_tip_route` test for the deleted route.

### Tests added
- `test_webapp_popup_removed.py`: Verifies the homepage no longer contains `mobile-prompt` elements, no "Install the" text, and the `/dismiss_mobile_tip` endpoint returns 404.

## Test plan
- [ ] Verify homepage loads cleanly on mobile without popup
- [ ] Verify no JS console errors from missing popup elements
- [ ] CI tests pass

Generated with [Claude Code](https://claude.com/claude-code)