### PR TITLE
fix: show post approve button properly on mobile (#720)

### DIFF
--- a/files/assets/js/filter_actions.js
+++ b/files/assets/js/filter_actions.js
@@ -26,6 +26,12 @@ function filter_new_status(id, new_status) {
 						approveLink.parentElement.removeChild(approveLink);
 						removeLink.parentElement.removeChild(removeLink);
 					}
+					const approveLinkMobile = postRow.querySelector('a#filter-approve-mobile')
+					const removeLinkMobile = postRow.querySelector('a#filter-remove-mobile')
+					if(approveLinkMobile && removeLinkMobile) {
+						approveLinkMobile.parentElement.removeChild(approveLinkMobile);
+						removeLinkMobile.parentElement.removeChild(removeLinkMobile);
+					}
 
 					const reportButtonCell = document.getElementById(`flaggers-${id}`);
 					if(reportButtonCell) {

--- a/files/templates/component/post/actions_admin_mobile.html
+++ b/files/templates/component/post/actions_admin_mobile.html
@@ -22,8 +22,8 @@
 					{%- if v and v.admin_level >= PERMS['POST_COMMENT_MODERATION'] -%}
 						{%- set show_approve = p.state_mod != StateMod.VISIBLE or "/reported/" in request.path -%}
 						{%- set show_remove = p.state_mod != StateMod.REMOVED -%}
-						<a id="remove2-{{p.id}}" class="dropdown-item list-inline-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" data-bs-dismiss="modal" onclick="moderate(true, {{p.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban"></i>Remove</a>
-						<a id="approve2-{{p.id}}" class="dropdown-item list-inline-item text-success{% if not show_approve %} d-none{% endif %}" role="button" data-bs-dismiss="modal" onclick="moderate(true, {{p.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check"></i>Approve</a>
+						<a id="remove2-{{p.id}}" class="list-group-item text-danger{% if not show_remove %} d-none{% endif %}" role="button" data-bs-dismiss="modal" onclick="moderate(true, {{p.id}}, true, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-ban mr-2"></i>Remove</a>
+						<a id="approve2-{{p.id}}" class="list-group-item text-success{% if not show_approve %} d-none{% endif %}" role="button" data-bs-dismiss="modal" onclick="moderate(true, {{p.id}}, false, 'remove-{{p.id}}', 'remove2-{{p.id}}', 'approve-{{p.id}}', 'approve2-{{p.id}}');"><i class="fas fa-check mr-2"></i>Approve</a>
 					{%- endif -%}
 
 					{% if p.oauth_app %}

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -370,8 +370,8 @@
 					{% endif %}
 
 					{% if v and v.admin_level >= 2 and p.state_mod == StateMod.FILTERED %}
-						<a id="filter-approve" class="btn btn-primary ml-2" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'normal')">Approve</a>
-						<a id="filter-remove" class="btn btn-danger ml-1" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'removed')">Remove</a>
+						<a id="filter-approve-mobile" class="btn btn-primary ml-2" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'normal')">Approve</a>
+						<a id="filter-remove-mobile" class="btn btn-danger ml-1" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'removed')">Remove</a>
 					{% endif %}
 				</li>
 

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -368,6 +368,11 @@
 							<i class="fas fa-broom"></i>
 						</a>
 					{% endif %}
+
+					{% if v and v.admin_level >= 2 and p.state_mod == StateMod.FILTERED %}
+						<a id="filter-approve" class="btn btn-primary ml-2" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'normal')">Approve</a>
+						<a id="filter-remove" class="btn btn-danger ml-1" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'removed')">Remove</a>
+					{% endif %}
 				</li>
 
 				{% if v %}

--- a/files/templates/submission_listing.html
+++ b/files/templates/submission_listing.html
@@ -253,8 +253,8 @@
 								{% endif %}
 
 								{% if v and v.admin_level >= 2 and p.state_mod == StateMod.FILTERED %}
-									<a id="filter-approve" class="btn btn-primary ml-2" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'normal')">Approve</a>
-									<a id="filter-remove" class="btn btn-danger ml-1" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'removed')">Remove</a>
+									<a id="filter-approve-mobile" class="btn btn-primary ml-2" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'normal')">Approve</a>
+									<a id="filter-remove-mobile" class="btn btn-danger ml-1" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'removed')">Remove</a>
 								{% endif %}
 
 							</li>

--- a/files/templates/submission_listing.html
+++ b/files/templates/submission_listing.html
@@ -251,7 +251,12 @@
 										<i class="fas fa-broom"></i>
 									</a>
 								{% endif %}
-			
+
+								{% if v and v.admin_level >= 2 and p.state_mod == StateMod.FILTERED %}
+									<a id="filter-approve" class="btn btn-primary ml-2" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'normal')">Approve</a>
+									<a id="filter-remove" class="btn btn-danger ml-1" style="padding:1px 5px; font-size:10px" role="button" onclick="filter_new_status({{p.id}}, 'removed')">Remove</a>
+								{% endif %}
+
 							</li>
 							
 							{% if p.realbody(v) and request.path != "/changelog"%}

--- a/files/tests/test_admin.py
+++ b/files/tests/test_admin.py
@@ -1012,6 +1012,86 @@ def test_admin_badge_remove_get():
 	assert response.status_code == 200
 
 
+def test_filtered_post_has_approve_button():
+	"""Test that a filtered post shows Approve/Remove buttons for admins (#720)"""
+	from files.__main__ import db_session
+	from files.classes import Submission
+	from files.classes.visstate import StateMod
+
+	admin_client, admin = util_accounts.create_test_client_and_admin(2, "fltappr-admin")
+
+	# Create a post as a regular user
+	client, user = util_accounts.create_test_client_and_user("fltappr-user")
+	post = util_submissions.create_submission_for_client(client)
+	post_id = post.id
+
+	# Set the post to FILTERED state
+	with util.test_db_session() as session:
+		post_obj = session.get(Submission, post_id)
+		post_obj.state_mod = StateMod.FILTERED
+		session.commit()
+
+	# Load the individual post page as admin
+	response = admin_client.get(f"/post/{post_id}")
+	assert response.status_code == 200
+	assert "filter-approve" in response.text
+	assert "filter-remove" in response.text
+
+
+def test_filtered_post_listing_has_approve_button():
+	"""Test that filtered posts listing shows Approve/Remove buttons (#720)"""
+	from files.__main__ import db_session
+	from files.classes import Submission
+	from files.classes.visstate import StateMod
+
+	admin_client, admin = util_accounts.create_test_client_and_admin(2, "fltlst-admin")
+
+	# Create a post as a regular user
+	client, user = util_accounts.create_test_client_and_user("fltlst-user")
+	post = util_submissions.create_submission_for_client(client)
+	post_id = post.id
+
+	# Set the post to FILTERED state
+	with util.test_db_session() as session:
+		post_obj = session.get(Submission, post_id)
+		post_obj.state_mod = StateMod.FILTERED
+		session.commit()
+
+	# Load the filtered posts admin page
+	response = admin_client.get("/admin/filtered/posts")
+	assert response.status_code == 200
+	assert "filter-approve" in response.text
+	assert "filter-remove" in response.text
+
+
+def test_filtered_post_mobile_actions_load():
+	"""Test that the mobile admin actions modal loads for filtered posts (#720)"""
+	from files.__main__ import db_session
+	from files.classes import Submission
+	from files.classes.visstate import StateMod
+
+	admin_client, admin = util_accounts.create_test_client_and_admin(2, "fltmob-admin")
+
+	# Create a post as a regular user
+	client, user = util_accounts.create_test_client_and_user("fltmob-user")
+	post = util_submissions.create_submission_for_client(client)
+	post_id = post.id
+
+	# Set the post to FILTERED state
+	with util.test_db_session() as session:
+		post_obj = session.get(Submission, post_id)
+		post_obj.state_mod = StateMod.FILTERED
+		session.commit()
+
+	# Load the individual post page as admin and check mobile admin actions exist
+	response = admin_client.get(f"/post/{post_id}")
+	assert response.status_code == 200
+	# The mobile actions template should include the list-group-item styled buttons
+	assert "list-group-item" in response.text
+	assert f"approve2-{post_id}" in response.text
+	assert f"remove2-{post_id}" in response.text
+
+
 def test_unsticky_post():
 	"""Test POST /unsticky/<post_id> route"""
 	from files.__main__ import db_session


### PR DESCRIPTION
Closes #720

## Summary
- Added inline filter approve/remove buttons to the mobile footer bar in both post listing and single post views, matching the desktop behavior where these buttons are directly visible for filtered posts
- Fixed CSS classes on approve/remove buttons in the admin mobile modal (`actions_admin_mobile.html`) from `dropdown-item list-inline-item` to `list-group-item` to match the parent `list-group` container, giving proper padding and consistent styling

## Changes
- `files/templates/submission_listing.html` -- added filter approve/remove buttons to mobile footer when post is filtered
- `files/templates/submission.html` -- same change for the single post view mobile bar
- `files/templates/component/post/actions_admin_mobile.html` -- fixed CSS classes on mod approve/remove from dropdown-item to list-group-item, added icon margin
- `files/tests/test_admin.py` -- added 3 page load tests for filtered post approve button rendering

## Testing
- Visual review of approve button placement on mobile-width viewports
- Verified button styling matches existing patterns (btn-primary for Approve, btn-danger for Remove, same padding/font-size as the Reports button)
- Verified admin modal approve/remove items now use list-group-item consistent with sibling elements
- **Automated tests added:**
  - `test_filtered_post_has_approve_button` -- loads individual filtered post page as admin, verifies approve/remove button markup
  - `test_filtered_post_listing_has_approve_button` -- loads /admin/filtered/posts with a filtered post, verifies buttons
  - `test_filtered_post_mobile_actions_load` -- verifies mobile admin actions modal renders list-group-item styled buttons

Generated with [Claude Code](https://claude.com/claude-code)