### PR TITLE
fix: improve password-reset email HTML formatting (#693)

### DIFF
--- a/files/templates/email/2fa_remove.html
+++ b/files/templates/email/2fa_remove.html
@@ -3,13 +3,12 @@
 {% block title %}Remove Two-Factor Authentication{% endblock %}
 
 {% block content %}
-	<p>We received a request to remove two-factor authentication from your account. In 72 hours, click the link below.</p>
-	<p>If you didn't make this request, change your password and use the Log Out Everywhere feature in your <a href="/settings/security">Security Settings</a> to permanently invalidate the link.</p>
-	<div class="button-container">
-		<a href="{{action_url}}" class="button" target="_blank" rel="noopener">Remove 2FA</a>
+	<p style="margin: 0 0 10px 0; color: #333333; line-height: 1.5; font-size: 15px;">We received a request to remove two-factor authentication from your account. In 72 hours, click the link below.</p>
+	<p style="margin: 0 0 10px 0; color: #333333; line-height: 1.5; font-size: 15px;">If you didn't make this request, change your password and use the Log Out Everywhere feature in your <a href="/settings/security">Security Settings</a> to permanently invalidate the link.</p>
+	<div style="text-align: center; margin: 30px 0 40px 0;">
+		<a href="{{action_url}}" style="display: inline-block; background-color: #1a6187; color: #ffffff; padding: 12px 28px; text-decoration: none; border-radius: 5px; font-size: 16px; font-weight: bold;" target="_blank" rel="noopener">Remove 2FA</a>
 	</div>
-
-	<p class="user-info">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
-	<hr />
-	<p class="raw-link">If the button doesn't work, you can copy and paste this link into your browser: <br>{{action_url}}</p>
+	<p style="font-size: 13px; color: #777777; margin: 16px 0; line-height: 1.4;">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
+	<hr style="border: none; border-top: 1px solid #e0e0e0; margin: 20px 0;" />
+	<p style="display: block; margin-top: 10px; font-size: 13px; text-align: left; color: #999999; word-wrap: break-word; line-height: 1.4;">If the button doesn't work, you can copy and paste this link into your browser: <br />{{action_url}}</p>
 {% endblock %}

--- a/files/templates/email/default.html
+++ b/files/templates/email/default.html
@@ -1,111 +1,27 @@
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta name="description" content="{{config('DESCRIPTION')}}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title></title>
-    <style type="text/css" rel="stylesheet" media="all">
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #f5f5f5;
-        }
-        .container {
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #ffffff;
-            border-radius: 5px;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-        }
-        h1 {
-            text-align: center;
-            color: #333333;
-        }
-        p {
-            margin-bottom: 10px;
-            color: #333333;
-            line-height: 1.25rem;
-        }
-        .button-container {
-            text-align: center;
-            margin-top: 30px;
-            margin-bottom: 40px;
-        }
-        .button {
-            display: inline-block;
-            background-color: #1a6187;
-            color: #ffffff;
-            padding: 10px 20px;
-            text-decoration: none;
-            border-radius: 5px;
-        }
-        .raw-link {
-            display: block;
-            margin-top: 10px;
-            font-size: 14px;
-            text-align: left;
-            color: #777777;
-            word-wrap: break-word;
-        }
-        .reference-text {
-            margin-top: 20px;
-            font-size: 14px;
-            line-height: 1rem;
-        }
-        .user-info {
-            font-size: 14px;
-            color: #333333;
-        }
-        .user-info p {
-            margin-left: 20px;
-            line-height: 1rem;
-        }
-        @media (prefers-color-scheme: dark) {
-            body {
-                background-color: #222222;
-                color: #ffffff;
-            }
-            h1 {
-                color: #ffffff;
-            }
-            p {
-                color: #cccccc;
-            }
-            .container {
-                background-color: #1d323d;
-            }
-            .button {
-                background-color: #2280B3;
-            }
-            .raw-link {
-                color: #cccccc;
-            }
-            .reference-text {
-                color: #cccccc;
-            }
-            .user-info {
-                color: #cccccc;
-            }
-        }
-        @media screen and (max-width: 600px) {
-            .container {
-                padding: 10px;
-            }
-            h1 {
-                font-size: 24px;
-            }
-        }
-    </style>
   </head>
-  <body>
-    <div class="container">
-    <h1>{% block title %}{% endblock %}</h1>
-      {% block content %}
-      {% endblock %}
-    </div>
+  <body style="font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif; margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: #f5f5f5;">
+      <tr>
+        <td align="center" style="padding: 30px 10px;">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; border: 1px solid #e0e0e0;">
+            <tr>
+              <td style="padding: 40px 30px;">
+                <h1 style="text-align: center; color: #333333; font-size: 22px; font-weight: bold; margin: 0 0 24px 0; line-height: 1.3;">{% block title %}{% endblock %}</h1>
+                {% block content %}
+                {% endblock %}
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/files/templates/email/email_change.html
+++ b/files/templates/email/email_change.html
@@ -1,18 +1,18 @@
 {% extends "email/default.html" %}
 
-{% block title %}Verify your new {{SITE_TITLE}} email.{% endblock %}</h1>
+{% block title %}Verify your new {{SITE_TITLE}} email.{% endblock %}
 
 {% block content %}
-	<p>You told us you wanted to change your {{SITE_TITLE}} account email. To finish this process, please verify your new email address:</p>
-	<div class="button-container">
-			<a href="{{action_url}}" class="button" target="_blank" rel="noopener">Verify Email</a>
+	<p style="margin: 0 0 10px 0; color: #333333; line-height: 1.5; font-size: 15px;">You told us you wanted to change your {{SITE_TITLE}} account email. To finish this process, please verify your new email address:</p>
+	<div style="text-align: center; margin: 30px 0 40px 0;">
+		<a href="{{action_url}}" style="display: inline-block; background-color: #1a6187; color: #ffffff; padding: 12px 28px; text-decoration: none; border-radius: 5px; font-size: 16px; font-weight: bold;" target="_blank" rel="noopener">Verify Email</a>
 	</div>
-	<p class="reference-text">For reference, here's your current information:</p>
-	<div class="user-info">
-		<p><strong>Username:</strong> {{v.username}}</p>
-		<p><strong>Email:</strong> {{v.email}}</p>
+	<p style="margin: 20px 0 10px 0; color: #333333; font-size: 14px; line-height: 1.4;">For reference, here's your current information:</p>
+	<div style="font-size: 14px; color: #333333; padding: 12px 20px; background-color: #f9f9f9; border-radius: 4px; margin-bottom: 16px;">
+		<p style="margin: 4px 0; color: #333333; line-height: 1.4;"><strong>Username:</strong> {{v.username}}</p>
+		<p style="margin: 4px 0; color: #333333; line-height: 1.4;"><strong>Email:</strong> {{v.email}}</p>
 	</div>
-	<p class="user-info">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
-	<hr />
-	<p class="raw-link">If the button doesn't work, you can copy and paste this link into your browser: <br>{{action_url}}</p>
+	<p style="font-size: 13px; color: #777777; margin: 16px 0; line-height: 1.4;">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
+	<hr style="border: none; border-top: 1px solid #e0e0e0; margin: 20px 0;" />
+	<p style="display: block; margin-top: 10px; font-size: 13px; text-align: left; color: #999999; word-wrap: break-word; line-height: 1.4;">If the button doesn't work, you can copy and paste this link into your browser: <br />{{action_url}}</p>
 {% endblock %}

--- a/files/templates/email/email_verify.html
+++ b/files/templates/email/email_verify.html
@@ -3,16 +3,16 @@
 {% block title %}Welcome to {{SITE_TITLE}}!{% endblock %}
 
 {% block content %}
-	<p>Thanks for joining {{SITE_TITLE}}. We’re happy to have you on board. Please click the button below to verify your email address:</p>
-	<div class="button-container">
-		<a href="{{action_url}}" class="button" target="_blank" rel="noopener">Verify Email</a>
+	<p style="margin: 0 0 10px 0; color: #333333; line-height: 1.5; font-size: 15px;">Thanks for joining {{SITE_TITLE}}. We're happy to have you on board. Please click the button below to verify your email address:</p>
+	<div style="text-align: center; margin: 30px 0 40px 0;">
+		<a href="{{action_url}}" style="display: inline-block; background-color: #1a6187; color: #ffffff; padding: 12px 28px; text-decoration: none; border-radius: 5px; font-size: 16px; font-weight: bold;" target="_blank" rel="noopener">Verify Email</a>
 	</div>
-	<p class="reference-text">For reference, here's your username:</p>
-	<div class="user-info">
-		<p><strong>Username:</strong> {{v.username}}</p>
-		<p><strong>Email:</strong> {{v.email}}</p>
+	<p style="margin: 20px 0 10px 0; color: #333333; font-size: 14px; line-height: 1.4;">For reference, here's your username:</p>
+	<div style="font-size: 14px; color: #333333; padding: 12px 20px; background-color: #f9f9f9; border-radius: 4px; margin-bottom: 16px;">
+		<p style="margin: 4px 0; color: #333333; line-height: 1.4;"><strong>Username:</strong> {{v.username}}</p>
+		<p style="margin: 4px 0; color: #333333; line-height: 1.4;"><strong>Email:</strong> {{v.email}}</p>
 	</div>
-	<p class="user-info">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
-	<hr />
-	<p class="raw-link">If the button doesn't work, you can copy and paste this link into your browser: <br>{{action_url}}</p>
+	<p style="font-size: 13px; color: #777777; margin: 16px 0; line-height: 1.4;">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
+	<hr style="border: none; border-top: 1px solid #e0e0e0; margin: 20px 0;" />
+	<p style="display: block; margin-top: 10px; font-size: 13px; text-align: left; color: #999999; word-wrap: break-word; line-height: 1.4;">If the button doesn't work, you can copy and paste this link into your browser: <br />{{action_url}}</p>
 {% endblock %}

--- a/files/templates/email/password_reset.html
+++ b/files/templates/email/password_reset.html
@@ -3,16 +3,16 @@
 {% block title %}Reset your {{SITE_TITLE}} password.{% endblock %}
 
 {% block content %}
-	<p>To reset your password, click the button below:</p>
-	<div class="button-container">
-		<a href="{{action_url}}" class="button" target="_blank" rel="noopener">Reset password</a>
+	<p style="margin: 0 0 10px 0; color: #333333; line-height: 1.5; font-size: 15px;">To reset your password, click the button below:</p>
+	<div style="text-align: center; margin: 30px 0 40px 0;">
+		<a href="{{action_url}}" style="display: inline-block; background-color: #1a6187; color: #ffffff; padding: 12px 28px; text-decoration: none; border-radius: 5px; font-size: 16px; font-weight: bold;" target="_blank" rel="noopener">Reset password</a>
 	</div>
-	<p class="reference-text">For reference, here's your login information:</p>
-	<div class="user-info">
-		<p><strong>Username:</strong> {{v.username}}</p>
-		<p><strong>Email:</strong> {{v.email}}</p>
+	<p style="margin: 20px 0 10px 0; color: #333333; font-size: 14px; line-height: 1.4;">For reference, here's your login information:</p>
+	<div style="font-size: 14px; color: #333333; padding: 12px 20px; background-color: #f9f9f9; border-radius: 4px; margin-bottom: 16px;">
+		<p style="margin: 4px 0; color: #333333; line-height: 1.4;"><strong>Username:</strong> {{v.username}}</p>
+		<p style="margin: 4px 0; color: #333333; line-height: 1.4;"><strong>Email:</strong> {{v.email}}</p>
 	</div>
-	<p class="user-info">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
-	<hr />
-	<p class="raw-link">If the button doesn't work, you can copy and paste this link into your browser: <br>{{action_url}}</p>
+	<p style="font-size: 13px; color: #777777; margin: 16px 0; line-height: 1.4;">Please note that {{SITE_TITLE}} will never ask you for your email, password, or two-factor token via email, text, or phone.</p>
+	<hr style="border: none; border-top: 1px solid #e0e0e0; margin: 20px 0;" />
+	<p style="display: block; margin-top: 10px; font-size: 13px; text-align: left; color: #999999; word-wrap: break-word; line-height: 1.4;">If the button doesn't work, you can copy and paste this link into your browser: <br />{{action_url}}</p>
 {% endblock %}

--- a/files/tests/test_email_templates.py
+++ b/files/tests/test_email_templates.py
@@ -1,0 +1,88 @@
+"""Tests for email template rendering (#693).
+
+Verifies that all email templates render without errors and use inline
+styles instead of CSS classes (for email client compatibility).
+"""
+from . import util_accounts
+
+
+def test_forgot_password_page_renders():
+	"""Test that the forgot password page loads (entry point for password reset email)"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/forgot")
+	assert response.status_code == 200
+	assert "password" in response.text.lower()
+
+
+def test_forgot_password_post_triggers_email_render():
+	"""Test that posting to /forgot renders the password reset email template"""
+	client, user = util_accounts.create_test_client_and_user(name="email-test")
+
+	username = user.username
+	client.get("/logout")
+
+	# Post to forgot endpoint - even with wrong email, the template path is exercised
+	response = client.post("/forgot", data={
+		"username": username,
+		"email": "test@example.com"
+	})
+	# Should return 200 with a message (not crash on template rendering)
+	assert response.status_code == 200
+
+
+def test_email_templates_no_css_classes():
+	"""Verify email templates use inline styles, not CSS class references.
+
+	Since the base email template (default.html) no longer has a <style> block,
+	child templates must use inline styles for all visual formatting.
+	"""
+	from files.__main__ import app
+
+	# List of email templates and their required context variables
+	templates = {
+		"email/password_reset.html": {"v": type("User", (), {"username": "test", "email": "test@example.com"})(), "action_url": "https://example.com/reset"},
+		"email/email_change.html": {"v": type("User", (), {"username": "test", "email": "test@example.com"})(), "action_url": "https://example.com/verify"},
+		"email/email_verify.html": {"v": type("User", (), {"username": "test", "email": "test@example.com"})(), "action_url": "https://example.com/verify"},
+		"email/2fa_remove.html": {"action_url": "https://example.com/remove_2fa"},
+	}
+
+	css_classes_to_check = ["button-container", "button\"", "raw-link", "user-info", "reference-text"]
+
+	with app.app_context():
+		from flask import render_template
+		for template_name, context in templates.items():
+			html = render_template(template_name, **context)
+			for css_class in css_classes_to_check:
+				assert f'class="{css_class.rstrip(chr(34))}"' not in html, \
+					f"Template {template_name} still uses CSS class '{css_class}' - should use inline styles"
+
+
+def test_email_default_template_uses_table_layout():
+	"""Verify the base email template uses table-based layout for email compatibility"""
+	from files.__main__ import app
+
+	with app.app_context():
+		from flask import render_template
+		html = render_template("email/password_reset.html",
+			v=type("User", (), {"username": "test", "email": "test@example.com"})(),
+			action_url="https://example.com/reset"
+		)
+		# Should use table-based layout (email best practice)
+		assert "<table" in html
+		assert 'role="presentation"' in html
+		# Should NOT have a <style> block (inline styles only)
+		assert "<style" not in html
+
+
+def test_email_change_template_no_stray_closing_tag():
+	"""Verify the stray </h1> after {% endblock %} in email_change.html is fixed"""
+	import os
+	template_path = os.path.join(
+		os.path.dirname(os.path.dirname(__file__)),
+		"templates", "email", "email_change.html"
+	)
+	with open(template_path) as f:
+		content = f.read()
+	# The old template had: {% endblock %}</h1> which is invalid
+	assert "endblock %}</h1>" not in content


### PR DESCRIPTION
## Summary

Fixes #693 -- the password-reset email (and all other transactional emails) looked broken because email clients strip `<style>` blocks and ignore CSS classes.

### Changes
- **`email/default.html`**: Replaced `<div>` + CSS class layout with table-based layout using inline styles. Added `xmlns` attribute for XHTML email compatibility. Removed the entire `<style>` block.
- **`email/password_reset.html`**: Converted all CSS class references to inline styles.
- **`email/email_change.html`**: Converted to inline styles. Fixed stray `</h1>` tag after `{% endblock %}`.
- **`email/email_verify.html`**: Converted to inline styles.
- **`email/2fa_remove.html`**: Converted to inline styles (was missed in the initial commit, would have rendered unstyled).

### Why table-based + inline styles?
Email clients (Gmail, Outlook, Yahoo, Apple Mail) have notoriously poor CSS support. `<style>` blocks are stripped by many clients (especially Gmail on mobile). Table-based layout with inline styles is the industry standard for HTML email.

## Design Decision

The original email template included a `@media (prefers-color-scheme: dark)` CSS block (supported by Apple Mail, iOS Mail, Outlook.com). This was removed because:
- Gmail (the most common email client) strips all `<style>` blocks entirely
- The new table-based layout uses inline styles for maximum client compatibility
- Dark mode via CSS-in-email has inconsistent support across clients

If preserving dark mode support is important, the inline styles can be extended with dark-mode-compatible colors. Let me know.

### Tests added
- `test_email_templates.py`: Verifies templates render without errors, use no CSS class references, use table-based layout, and the stray `</h1>` fix is in place.

## Test plan
- [ ] Verify email templates render in CI tests
- [ ] Manual: trigger a password reset email and verify it displays correctly
- [ ] Manual: check email rendering in Gmail, Outlook, and Apple Mail

Generated with [Claude Code](https://claude.com/claude-code)