### PR TITLE
Fix tildes in URLs mangled by strikethrough regex (#737)

### DIFF
--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -101,6 +101,17 @@ def allowed_attributes(tag, name, value):
 		return False
 
 
+_tag_or_strikethrough_regex = re.compile(r'(<[^>]+>)|(~{1,2})([^~]+?)\2', flags=re.A)
+
+def _strikethrough_replace(m):
+	if m.group(1):  # matched an HTML tag — return unchanged
+		return m.group(1)
+	return '<del>' + m.group(3) + '</del>'
+
+def _apply_strikethrough(text):
+	"""Apply strikethrough formatting only to text outside HTML tags."""
+	return _tag_or_strikethrough_regex.sub(_strikethrough_replace, text)
+
 url_re = build_url_re(tlds=TLDS, protocols=['http', 'https'])
 
 css_sanitizer = CSSSanitizer(allowed_css_properties=['color', 'background-color', 'font-weight', 'text-align'])
@@ -186,7 +197,8 @@ def sanitize(sanitized, alert=False, comment=False, edit=False):
 	sanitized = markdown(sanitized)
 
 	# turn ~something~ or ~~something~~  into <del>something</del>
-	sanitized = strikethrough_regex.sub(r'<del>\1</del>', sanitized)
+	# skip text inside HTML tags so tildes in URLs aren't mangled (fixes #737)
+	sanitized = _apply_strikethrough(sanitized)
 
 	# remove left-to-right mark; remove zero width space; remove zero width no-break space; remove Cuneiform Numeric Sign Eight;
 	sanitized = unwanted_bytes_regex.sub('', sanitized)

--- a/files/tests/test_sanitize.py
+++ b/files/tests/test_sanitize.py
@@ -1,0 +1,262 @@
+"""Tests for tilde handling in files/helpers/sanitize.py.
+
+Covers the tag-aware strikethrough regex that fixes #737:
+tildes inside HTML tag attributes (e.g., href URLs) must not be
+interpreted as strikethrough markers.
+
+NOTE: We cannot import `_apply_strikethrough` directly from
+`files.helpers.sanitize` because the module's top-level imports pull in
+Flask, SQLAlchemy, and environment config that requires a running app.
+Instead, we extract the regex pattern and replacement function from the
+source file and test them directly. A meta-test verifies the pattern
+stays in sync with the source.
+"""
+
+import re
+import textwrap
+import time
+
+
+# ---------------------------------------------------------------------------
+# Reproduce the exact regex and replacement logic from sanitize.py so we can
+# test without triggering the heavy import chain.  The meta-test at the bottom
+# ensures these stay in sync with the real source.
+# ---------------------------------------------------------------------------
+
+_tag_or_strikethrough_regex = re.compile(
+	r'(<[^>]+>)|(~{1,2})([^~]+?)\2', flags=re.A
+)
+
+def _strikethrough_replace(m):
+	if m.group(1):  # matched an HTML tag -- return unchanged
+		return m.group(1)
+	return '<del>' + m.group(3) + '</del>'
+
+def _apply_strikethrough(text):
+	"""Apply strikethrough formatting only to text outside HTML tags."""
+	return _tag_or_strikethrough_regex.sub(_strikethrough_replace, text)
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+class TestStrikethroughBasic:
+	"""Verify that strikethrough formatting still works correctly."""
+
+	def test_single_tilde_strikethrough(self):
+		result = _apply_strikethrough("hello ~world~ there")
+		assert result == "hello <del>world</del> there"
+
+	def test_double_tilde_strikethrough(self):
+		result = _apply_strikethrough("hello ~~world~~ there")
+		assert result == "hello <del>world</del> there"
+
+	def test_multiple_single_strikethroughs(self):
+		result = _apply_strikethrough("~a~ and ~b~ and ~c~")
+		assert result == "<del>a</del> and <del>b</del> and <del>c</del>"
+
+	def test_multiple_double_strikethroughs(self):
+		result = _apply_strikethrough("~~a~~ and ~~b~~")
+		assert result == "<del>a</del> and <del>b</del>"
+
+	def test_strikethrough_with_spaces(self):
+		result = _apply_strikethrough("~multiple words here~")
+		assert result == "<del>multiple words here</del>"
+
+	def test_no_tildes_unchanged(self):
+		text = "no tildes in this text at all"
+		result = _apply_strikethrough(text)
+		assert result == text
+
+	def test_single_tilde_alone_unchanged(self):
+		"""A lone tilde with no matching pair should not be altered."""
+		text = "this has a ~ lone tilde"
+		result = _apply_strikethrough(text)
+		assert result == text
+
+
+class TestTildeInUrls:
+	"""Verify that tildes inside HTML tag attributes are preserved (#737)."""
+
+	def test_url_with_tilde_in_href(self):
+		"""Core bug: tilde in href must not be mangled."""
+		text = '<a href="https://example.com/~user/page">link</a>'
+		result = _apply_strikethrough(text)
+		assert result == text
+
+	def test_url_with_text_fragment_tilde(self):
+		"""Text fragment anchors use :~: syntax which must be preserved."""
+		text = '<a href="https://example.com/page#:~:text=foo">link</a>'
+		result = _apply_strikethrough(text)
+		assert result == text
+
+	def test_url_with_multiple_tildes_in_href(self):
+		text = '<a href="https://example.com/~user/~config/~data">link</a>'
+		result = _apply_strikethrough(text)
+		assert result == text
+
+	def test_two_links_with_tildes_not_paired(self):
+		"""Two separate links each containing a tilde must not pair across tags.
+
+		The old regex would match the ~ in the first href with the ~ in the
+		second href, creating <del>...</del> that spans across tags and
+		corrupts the HTML.
+		"""
+		text = (
+			'<a href="https://example.com/~user">a</a>'
+			' and '
+			'<a href="https://other.com/~test">b</a>'
+		)
+		result = _apply_strikethrough(text)
+		assert result == text
+
+	def test_exact_bug_report_scenario(self):
+		"""Reproduce the exact scenario from issue #737."""
+		text = (
+			'<a href="https://www.newsweek.com/von-spakovsky-voter-fraud-trump-632422'
+			'#:~:text=investigating%20imagined%20transgressions,Trump%20plainly%20craves"'
+			' rel="nofollow noopener noreferrer" target="_blank">voter ID requirements</a>'
+		)
+		result = _apply_strikethrough(text)
+		assert result == text
+		assert "<del>" not in result
+
+	def test_url_tilde_plus_strikethrough_text(self):
+		"""URL with tilde AND strikethrough text should both work correctly."""
+		text = '<a href="https://example.com/~user">link</a> some ~deleted~ words'
+		result = _apply_strikethrough(text)
+		assert 'href="https://example.com/~user"' in result
+		assert "<del>deleted</del>" in result
+
+	def test_markdown_link_with_tilde_after_conversion(self):
+		"""After markdown conversion, a link like [text](url~tilde) becomes HTML.
+
+		This tests the HTML that markdown would produce from such a link.
+		"""
+		text = '<a href="https://example.com/~user/page">click here</a>'
+		result = _apply_strikethrough(text)
+		assert 'href="https://example.com/~user/page"' in result
+		assert "<del>" not in result
+
+
+class TestStrikethroughWithHtmlTags:
+	"""Verify strikethrough works correctly alongside various HTML elements."""
+
+	def test_strikethrough_between_paragraph_tags(self):
+		result = _apply_strikethrough("<p>~test~</p>")
+		assert result == "<p><del>test</del></p>"
+
+	def test_strikethrough_after_br(self):
+		result = _apply_strikethrough("<br>~test~")
+		assert result == "<br><del>test</del>"
+
+	def test_self_closing_tag_with_tilde_preserved(self):
+		text = '<img src="/images/test~img.webp" />'
+		result = _apply_strikethrough(text)
+		assert result == text
+
+	def test_strikethrough_around_inline_tag(self):
+		"""Strikethrough markers split by an HTML tag should not pair across it."""
+		text = "~before <strong>bold</strong> after~"
+		result = _apply_strikethrough(text)
+		# The <strong> tag is consumed by the tag branch, splitting the text.
+		# The pieces "~before " and " after~" cannot form a valid pair.
+		assert "<strong>bold</strong>" in result
+
+	def test_mixed_tags_and_strikethrough(self):
+		text = '<p>~one~ <a href="url~with~tilde">link</a> ~two~</p>'
+		result = _apply_strikethrough(text)
+		assert "<del>one</del>" in result
+		assert "<del>two</del>" in result
+		assert 'href="url~with~tilde"' in result
+
+	def test_nested_tags_preserved(self):
+		text = '<a href="~url~"><span class="test">text</span></a>'
+		result = _apply_strikethrough(text)
+		assert 'href="~url~"' in result
+		assert '<span class="test">' in result
+
+
+class TestEdgeCases:
+	"""Edge cases and regression tests."""
+
+	def test_empty_string(self):
+		assert _apply_strikethrough("") == ""
+
+	def test_only_tildes(self):
+		"""String of only tildes should not crash or produce unexpected output."""
+		result = _apply_strikethrough("~~~")
+		# The regex requires [^~]+? between tildes, so pure tildes won't match
+		assert result == "~~~"
+
+	def test_adjacent_strikethroughs(self):
+		result = _apply_strikethrough("~a~~b~")
+		assert "<del>a</del>" in result
+
+	def test_tilde_in_code_tag_content(self):
+		"""Tildes inside <code> tag content (not attributes) are still processed.
+
+		This is expected -- code block protection happens at the markdown
+		level before _apply_strikethrough is called.
+		"""
+		text = "<code>~test~</code>"
+		result = _apply_strikethrough(text)
+		assert "<code>" in result
+		assert "</code>" in result
+
+	def test_backreference_enforces_matching_tilde_count(self):
+		"""The backreference \\2 ensures ~ pairs with ~ and ~~ with ~~."""
+		# ~text~~ has mismatched tilde counts; should not produce <del>
+		text = "hello ~text~~ world"
+		result = _apply_strikethrough(text)
+		# The ~ before "text" should pair with the first ~ after "text",
+		# leaving one trailing ~
+		assert "<del>text</del>" in result
+
+	def test_long_content_no_catastrophic_backtracking(self):
+		"""Ensure the regex completes quickly on large input."""
+		large_text = (
+			'<a href="https://example.com/~user">link</a> ' * 100
+			+ '~strike~ ' * 100
+		)
+		start = time.monotonic()
+		result = _apply_strikethrough(large_text)
+		elapsed = time.monotonic() - start
+		assert elapsed < 1.0
+		assert result.count("<del>strike</del>") == 100
+
+	def test_multiline_content(self):
+		"""Strikethrough should work across typical multiline HTML."""
+		text = "<p>First line ~deleted~</p>\n<p>Second ~also~ line</p>"
+		result = _apply_strikethrough(text)
+		assert "<del>deleted</del>" in result
+		assert "<del>also</del>" in result
+
+
+class TestRegexSyncWithSource:
+	"""Verify that the test's local regex matches the one in sanitize.py."""
+
+	def test_regex_pattern_matches_source(self):
+		"""The regex pattern tested here must match the source file."""
+		import os
+		source_path = os.path.join(
+			os.path.dirname(__file__), '..', 'helpers', 'sanitize.py'
+		)
+		with open(source_path) as f:
+			source = f.read()
+
+		# Extract the regex pattern from the source
+		match = re.search(
+			r"_tag_or_strikethrough_regex\s*=\s*re\.compile\(r'(.+?)'",
+			source
+		)
+		assert match is not None, (
+			"Could not find _tag_or_strikethrough_regex in sanitize.py"
+		)
+		source_pattern = match.group(1)
+		test_pattern = _tag_or_strikethrough_regex.pattern
+		assert source_pattern == test_pattern, (
+			f"Test regex pattern {test_pattern!r} does not match "
+			f"source pattern {source_pattern!r} -- update the test"
+		)


### PR DESCRIPTION
Closes #737

## Problem

The `strikethrough_regex` (`~{1,2}([^~]+)~{1,2}`) was applied to the entire HTML string after Markdown conversion. This meant a `~` inside one `<a href="...">` could pair with a `~` in another tag or in text content, creating a `<del>...</del>` span that corrupted the HTML structure.

**Example of the bug:** Two links each containing a tilde would be mangled:
```
Input:  <a href="https://example.com/~user">a</a> and <a href="https://other.com/~test">b</a>
Output: <a href="https://example.com/<del>user">a</a> and <a href="https://other.com/</del>test">b</a>
```

This particularly affected [text fragment anchors](https://web.dev/articles/text-fragments) which use `:~:` syntax in URLs.

## Solution

Replaced the flat regex substitution with a tag-aware regex that uses alternation to match HTML tags first:

```python
_tag_or_strikethrough_regex = re.compile(r'(<[^>]+>)|(~{1,2})([^~]+?)\2', flags=re.A)
```

- **First alternative** `(<[^>]+>)` matches any HTML tag and returns it unchanged
- **Second alternative** `(~{1,2})([^~]+?)\2` matches strikethrough with a backreference ensuring the opening and closing tilde counts match (stricter than the original)

The replacement function checks which alternative matched and only applies `<del>` wrapping to the strikethrough branch.

### Behavioral improvements over the original regex

1. **Tag-aware**: Tildes inside HTML attributes are never processed
2. **Backreference matching**: The `\2` backreference ensures `~text~` and `~~text~~` match correctly, whereas the original `~{1,2}([^~]+)~{1,2}` would accept mismatched counts like `~text~~`
3. **Non-greedy**: `[^~]+?` prevents over-matching in strings with multiple strikethrough regions

### Known limitations

- The tag regex `<[^>]+>` would fail on HTML attributes containing literal `>` characters (e.g., `<a title="a > b">`). In practice, the markdown/bleach pipeline does not produce such output.
- `filter_emojis_only()` (used for post titles) still uses the original `strikethrough_regex`. Titles don't contain HTML links, so this is not a bug, but could be unified in a future cleanup.

## Test coverage

28 tests in `files/tests/test_sanitize.py` covering:

- **Basic strikethrough** (7 tests): single `~`, double `~~`, multiple instances, spaces, lone tildes
- **URL preservation** (7 tests): tilde in href, text fragment anchors, multiple tildes, two links with tildes, the exact bug report scenario, mixed URL + strikethrough
- **HTML tag interaction** (6 tests): paragraph tags, `<br>`, self-closing tags, inline tags, mixed content, nested tags
- **Edge cases** (7 tests): empty string, only tildes, adjacent strikethroughs, code tags, backreference enforcement, catastrophic backtracking resistance, multiline
- **Source sync** (1 test): verifies the test's regex pattern matches the source file

Tests are self-contained (no Flask/DB dependency) and run with `pytest --noconftest files/tests/test_sanitize.py`.

## Test plan
- [x] Unit tests pass (28/28)
- [ ] Post a comment with `[link](https://example.com/~user/page)` -- URL renders correctly
- [ ] Post a comment with `[text](https://example.com/page#:~:text=foo)` -- text fragment preserved
- [ ] Post `~strikethrough~` and `~~strikethrough~~` -- both render as strikethrough
- [ ] Post a comment combining a tilde URL and strikethrough text -- both work independently