### PR TITLE
Fix OpenGraph tags on all important pages

### DIFF
--- a/files/templates/default.html
+++ b/files/templates/default.html
@@ -41,21 +41,18 @@
 	{% block title %}
 	<title>{{SITE_TITLE}}</title>
 
-	<meta property="og:type" content="article">
+	<meta property="og:type" content="website">
 	<meta property="og:title" content="{{SITE_TITLE}}">
-	<meta property="og:site_name" content="{{request.host}}">
-	<meta property="og:image" content="{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+	<meta property="og:site_name" content="{{SITE_TITLE}}">
+	<meta property="og:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
 	<meta property="og:url" content="{{SITE_FULL}}{{request.full_path}}">
 	<meta property="og:description" name="description" content="{{config('DESCRIPTION')}}">
-	<meta property="og:author" name="author" content="{{SITE_FULL}}">
-	<meta property="og:site_name" content="{{request.host}}">
 
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:site" content="{{SITE_FULL}}">
 	<meta name="twitter:title" content="{{SITE_TITLE}}">
-	<meta name="twitter:creator" content="{{SITE_FULL}}">
 	<meta name="twitter:description" content="{{config('DESCRIPTION')}}">
-	<meta name="twitter:image" content="{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+	<meta name="twitter:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
 	<meta name="twitter:url" content="{{SITE_FULL}}{{request.full_path}}">
 	{% endblock %}
 

--- a/files/templates/errors/error.html
+++ b/files/templates/errors/error.html
@@ -1,6 +1,19 @@
 {% extends "default.html" %}
 {% block title %}
-<title>{{code}} {{error}}</title>
+<title>{{code}} {{error}} - {{SITE_TITLE}}</title>
+
+<meta property="og:type" content="website">
+<meta property="og:title" content="{{code}} {{error}} - {{SITE_TITLE}}">
+<meta property="og:site_name" content="{{SITE_TITLE}}">
+<meta property="og:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+<meta property="og:url" content="{{SITE_FULL}}{{request.full_path}}">
+<meta property="og:description" name="description" content="{{description}}">
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="{{SITE_FULL}}">
+<meta name="twitter:title" content="{{code}} {{error}} - {{SITE_TITLE}}">
+<meta name="twitter:description" content="{{description}}">
+<meta name="twitter:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
 {% endblock %}
 {% block pagetype %}error-{{code}}{% endblock %}
 {% block content %}

--- a/files/templates/login/authforms.html
+++ b/files/templates/login/authforms.html
@@ -6,6 +6,20 @@
 		<meta name="description" content="{{config('DESCRIPTION')}}">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		<title>{% block pagetitle %}{{SITE_TITLE}}{% endblock %}</title>
+
+		<meta property="og:type" content="website">
+		<meta property="og:title" content="{{SITE_TITLE}}">
+		<meta property="og:site_name" content="{{SITE_TITLE}}">
+		<meta property="og:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+		<meta property="og:url" content="{{SITE_FULL}}{{request.full_path}}">
+		<meta property="og:description" name="description" content="{{config('DESCRIPTION')}}">
+
+		<meta name="twitter:card" content="summary">
+		<meta name="twitter:site" content="{{SITE_FULL}}">
+		<meta name="twitter:title" content="{{SITE_TITLE}}">
+		<meta name="twitter:description" content="{{config('DESCRIPTION')}}">
+		<meta name="twitter:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+
 		{% if v %}
 			<style>:root{--primary:#{{v.themecolor}}}</style>
 			<link rel="stylesheet" href="{{ 'css/main.css' | asset }}">

--- a/files/templates/settings.html
+++ b/files/templates/settings.html
@@ -13,22 +13,19 @@
 	<link rel="icon" type="image/png" href="{{ ('images/'~SITE_ID~'/icon.webp') | asset }}">
 
 	<title>{% block pagetitle %}Settings - {{SITE_TITLE}}{% endblock %}</title>
-		<meta property="og:type" content="article">
-		<meta property="og:title" content="{{SITE_TITLE}}">
-		<meta property="og:site_name" content="{{request.host}}">
-		<meta property="og:image" content="{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
-		<meta property="og:url" content="{{request.host}}">
+		<meta property="og:type" content="website">
+		<meta property="og:title" content="Settings - {{SITE_TITLE}}">
+		<meta property="og:site_name" content="{{SITE_TITLE}}">
+		<meta property="og:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+		<meta property="og:url" content="{{SITE_FULL}}{{request.full_path}}">
 		<meta property="og:description" name="description" content="{{config('DESCRIPTION')}}">
-		<meta property="og:author" name="author" content="{{SITE_FULL}}">
-		<meta property="og:site_name" content="{{request.host}}">
 
 		<meta name="twitter:card" content="summary_large_image">
 		<meta name="twitter:site" content="{{SITE_FULL}}">
-		<meta name="twitter:title" content="{{SITE_TITLE}}">
-		<meta name="twitter:creator" content="{{SITE_FULL}}">
+		<meta name="twitter:title" content="Settings - {{SITE_TITLE}}">
 		<meta name="twitter:description" content="{{config('DESCRIPTION')}}">
-		<meta name="twitter:image" content="{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
-		<meta name="twitter:url" content="{{request.host}}">
+		<meta name="twitter:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+		<meta name="twitter:url" content="{{SITE_FULL}}{{request.full_path}}">
 
 
 	<style>:root{--primary:#{{v.themecolor}}}</style>

--- a/files/templates/settings2.html
+++ b/files/templates/settings2.html
@@ -16,21 +16,18 @@
 	<meta name="thumbnail" content="{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
 	<link rel="icon" type="image/png" href="{{ ('images/'~SITE_ID~'/icon.webp') | asset }}">
 
-	<meta property="og:type" content="article">
+	<meta property="og:type" content="website">
 	<meta property="og:title" content="{{SITE_TITLE}}">
-	<meta property="og:site_name" content="{{request.host}}">
-	<meta property="og:image" content="{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+	<meta property="og:site_name" content="{{SITE_TITLE}}">
+	<meta property="og:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
 	<meta property="og:url" content="{{SITE_FULL}}{{request.full_path}}">
 	<meta property="og:description" name="description" content="{{config('DESCRIPTION')}}">
-	<meta property="og:author" name="author" content="{{SITE_FULL}}">
-	<meta property="og:site_name" content="{{request.host}}">
 
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:site" content="{{SITE_FULL}}">
 	<meta name="twitter:title" content="{{SITE_TITLE}}">
-	<meta name="twitter:creator" content="{{SITE_FULL}}">
 	<meta name="twitter:description" content="{{config('DESCRIPTION')}}">
-	<meta name="twitter:image" content="{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+	<meta name="twitter:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
 	<meta name="twitter:url" content="{{SITE_FULL}}{{request.full_path}}">
 
 

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -46,14 +46,13 @@
 <meta property="article:published_time" content="{{comment_info.created_datetime}}">
 {% if comment_info.edited_utc %}<meta property="article:modified_time" content="{{comment_info.edited_string}}">{% endif %}
 <meta property="og:description" name="description" content="{{comment_info.plainbody(v)}}">
-<meta property="og:author" name="author" content="{{'@'+comment_info.author_name}}">
 <meta property="og:title" content="{{'@'+comment_info.author_name}} comments on {{p.plaintitle(v)}} - {{SITE_TITLE}}">
 <meta property="og:image" content="{% if p.is_image %}{{p.realurl(v)}}{% elif p.has_thumb%}{{p.thumb_url}}{% else %}{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}{% endif %}">
 {% if p.is_video %}
 	<meta property="og:video" content="{{p.realurl(v)}}">
 {% endif %}
 <meta property="og:url" content="{{comment_info.permalink}}">
-<meta property="og:site_name" content="{{request.host}}">
+<meta property="og:site_name" content="{{SITE_TITLE}}">
 
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="{{SITE_FULL}}">
@@ -61,7 +60,7 @@
 <meta name="twitter:creator" content="{{'@'+comment_info.author_name}}">
 <meta name="twitter:description" content="{{comment_info.plainbody(v)}}">
 <meta name="twitter:image" content="{% if p.is_image %}{{p.realurl(v)}}{% elif p.has_thumb%}{{p.thumb_url}}{% else %}{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}{% endif %}">
-<meta name="twitter:url" content="{{p.permalink}}">
+<meta name="twitter:url" content="{{comment_info.permalink}}">
 
 {% else %}
 <title>{{p.plaintitle(v)}} - {{SITE_TITLE}}</title>
@@ -78,7 +77,7 @@
 <meta property="og:video" content="{{p.realurl(v)}}">
 {% endif %}
 <meta property="og:url" content="{{p.permalink}}">
-<meta property="og:site_name" content="{{request.host}}">
+<meta property="og:site_name" content="{{SITE_TITLE}}">
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="{{SITE_FULL}}">

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -70,7 +70,6 @@
 <meta property="article:published_time" content="{{p.created_datetime}}">
 {% if p.edited_utc %}<meta property="article:modified_time" content="{{p.edited_string}}">{% endif %}
 <meta property="og:description" name="description" content="{{p.plainbody(v)}}">
-{% if p.author %}<meta property="og:author" name="author" content="{{'@'+p.author_name}}">{% endif %}
 <meta property="og:title" content="{{p.plaintitle(v)}} - {{SITE_TITLE}}">
 <meta property="og:image" content="{% if p.is_image %}{{p.realurl(v)}}{% elif p.has_thumb%}{{p.thumb_url}}{% else %}{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}{% endif %}">
 {% if p.url and p.is_video %}

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -11,6 +11,18 @@
 		<link rel="icon" type="image/png" href="{{ ('images/'~SITE_ID~'/icon.webp') | asset }}">
 		{% block title %}
 		<title>Create a post - {{SITE_TITLE}}</title>
+		<meta property="og:type" content="website">
+		<meta property="og:title" content="Create a post - {{SITE_TITLE}}">
+		<meta property="og:site_name" content="{{SITE_TITLE}}">
+		<meta property="og:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
+		<meta property="og:url" content="{{SITE_FULL}}{{request.full_path}}">
+		<meta property="og:description" name="description" content="{{config('DESCRIPTION')}}">
+
+		<meta name="twitter:card" content="summary">
+		<meta name="twitter:site" content="{{SITE_FULL}}">
+		<meta name="twitter:title" content="Create a post - {{SITE_TITLE}}">
+		<meta name="twitter:description" content="{{config('DESCRIPTION')}}">
+		<meta name="twitter:image" content="{{SITE_FULL}}{{ ('images/'~SITE_ID~'/site_preview.webp') | asset }}">
 		{% endblock %}
 
 		

--- a/files/templates/userpage.html
+++ b/files/templates/userpage.html
@@ -10,21 +10,20 @@
 {% endif %}
 
 <title>{{u.username}}'s profile - {{SITE_TITLE}}</title>
+<meta property="og:type" content="profile">
 <meta property="og:article:author" content="@{{u.username}}">
-<meta property="article:section" content="{{u.username}}'s profile - {{SITE_TITLE}}">
 <meta property="article:published_time" content="{{u.created_date}}">
 <meta property="og:description" name="description" content="Joined {{u.created_date}} - {% if u.stored_subscriber_count >=1 and not u.is_private and not u.is_nofollow %}{{u.stored_subscriber_count}} Followers - {% endif %}{% if not u.is_private %} {{0 if u.shadowbanned else u.post_count}} Posts - {{0 if u.shadowbanned else u.comment_count}} Comments - {% endif %}{{u.bio}}">
-<meta property="og:author" name="author" content="@{{u.username}}">
-<meta property="og:title" content="{{u.username}}">
+<meta property="og:title" content="{{u.username}}'s profile - {{SITE_TITLE}}">
 <meta property="og:image" content="{{u.banner_url}}">
 <meta property="og:url" content="{{u.url}}">
-<meta property="og:site_name" content="{{request.host}}">
+<meta property="og:site_name" content="{{SITE_TITLE}}">
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="{{SITE_FULL}}">
 <meta name="twitter:title" content="{{u.username}}'s profile - {{SITE_TITLE}}">
 <meta name="twitter:creator" content="@{{u.username}}">
-<meta name="twitter:description" content="Joined {{u.created_date}} - {% if u.stored_subscriber_count >=1 and not u.is_private and not u.is_nofollow %}{{u.stored_subscriber_count}} Followers -{% endif %} {% if not u.is_private %} {{0 if u.shadowbanned else u.post_count}} Posts - {{0 if u.shadowbanned else u.comment_count}} Comments - {% endif %}{{u.bio}}">
+<meta name="twitter:description" content="Joined {{u.created_date}} - {% if u.stored_subscriber_count >=1 and not u.is_private and not u.is_nofollow %}{{u.stored_subscriber_count}} Followers - {% endif %}{% if not u.is_private %} {{0 if u.shadowbanned else u.post_count}} Posts - {{0 if u.shadowbanned else u.comment_count}} Comments - {% endif %}{{u.bio}}">
 <meta name="twitter:image" content="{{u.banner_url}}">
 <meta name="twitter:url" content="{{u.url}}">
 {% endblock %}

--- a/files/tests/test_opengraph.py
+++ b/files/tests/test_opengraph.py
@@ -1,0 +1,127 @@
+"""Tests for OpenGraph meta tags (#130).
+
+Verifies that key pages include proper og:title, og:image, and og:site_name
+meta tags, and that image URLs are absolute (prefixed with SITE_FULL).
+"""
+from . import util_accounts
+from . import util_submissions
+
+
+def test_front_page_has_og_title():
+	"""Test that the front page includes og:title meta tag"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert 'og:title' in response.text
+
+
+def test_front_page_has_og_image():
+	"""Test that the front page includes og:image meta tag"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert 'og:image' in response.text
+
+
+def test_front_page_og_type_is_website():
+	"""Test that the front page uses og:type website (not article)"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert 'og:type' in response.text
+	# Should be "website" not "article" for the homepage
+	assert 'content="website"' in response.text
+
+
+def test_front_page_og_site_name_not_request_host():
+	"""Test that og:site_name uses SITE_TITLE, not request.host"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	# Should not use request.host (which would be 'localhost' in tests)
+	assert 'og:site_name' in response.text
+	# og:site_name should appear exactly once (no duplicates)
+	assert response.text.count('og:site_name') == 1
+
+
+def test_front_page_has_twitter_tags():
+	"""Test that the front page includes Twitter card meta tags"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert 'twitter:card' in response.text
+	assert 'twitter:title' in response.text
+	assert 'twitter:image' in response.text
+
+
+def test_post_page_has_og_title():
+	"""Test that a post page includes og:title meta tag"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+
+	response = client.get(f"/post/{post.id}")
+	assert response.status_code == 200
+	assert 'og:title' in response.text
+
+
+def test_post_page_has_og_image():
+	"""Test that a post page includes og:image meta tag"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+
+	response = client.get(f"/post/{post.id}")
+	assert response.status_code == 200
+	assert 'og:image' in response.text
+
+
+def test_post_page_og_type_is_article():
+	"""Test that a post page uses og:type article"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+
+	response = client.get(f"/post/{post.id}")
+	assert response.status_code == 200
+	assert 'content="article"' in response.text
+
+
+def test_login_page_has_og_tags():
+	"""Test that the login page includes OG meta tags"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/login")
+	assert response.status_code == 200
+	assert 'og:title' in response.text
+	assert 'og:image' in response.text
+
+
+def test_user_profile_has_og_tags():
+	"""Test that a user profile page includes OG meta tags"""
+	client, user = util_accounts.create_test_client_and_user()
+
+	response = client.get(f"/@{user.username}")
+	assert response.status_code == 200
+	assert 'og:title' in response.text
+	assert 'og:image' in response.text
+
+
+def test_user_profile_og_type_is_profile():
+	"""Test that a user profile page uses og:type profile"""
+	client, user = util_accounts.create_test_client_and_user()
+
+	response = client.get(f"/@{user.username}")
+	assert response.status_code == 200
+	assert 'content="profile"' in response.text
+
+
+def test_no_og_author_on_non_article_pages():
+	"""Test that og:author is not present on pages that are not articles"""
+	client = util_accounts.create_logged_off_client()
+
+	response = client.get("/")
+	assert response.status_code == 200
+	assert 'og:author' not in response.text


### PR DESCRIPTION
## Summary

Fixes #130 -- OpenGraph and Twitter Card meta tags were broken or missing across the site.

### Problems fixed
1. **Relative image URLs**: `og:image` and `twitter:image` used relative paths (e.g. `/assets/images/...`) which social media crawlers cannot resolve. Now prefixed with `SITE_FULL`.
2. **Wrong `og:site_name`**: Used `request.host` (raw hostname) instead of `SITE_TITLE` (human-readable name).
3. **Duplicate `og:site_name`**: `default.html` and `settings.html` had two `og:site_name` tags.
4. **Wrong `og:type`**: Homepage, settings, and other non-article pages used `og:type=article`. Now uses `website` for general pages, `article` for posts, `profile` for user pages.
5. **Invalid `og:author`**: Used on non-article pages. Removed where inappropriate, kept `twitter:creator` where it makes sense (post/comment authors, user profiles).
6. **Wrong `twitter:url`**: Submission comment view used `p.permalink` instead of `comment_info.permalink`.
7. **Missing OG tags**: Error pages, login/signup forms, and the submit page had no OG tags at all.

### Templates changed
- `default.html` -- Fixed base OG tags (type, site_name, image URLs, removed duplicates)
- `submission.html` -- Fixed post and comment OG tags, removed `og:author`
- `userpage.html` -- Added `og:type=profile`, fixed title/site_name/description
- `settings.html` -- Fixed all OG/Twitter tags, removed duplicates
- `settings2.html` -- Fixed OG/Twitter tags
- `errors/error.html` -- Added OG and Twitter tags
- `login/authforms.html` -- Added OG and Twitter tags
- `submit.html` -- Added OG and Twitter tags

### Tests added
- `test_opengraph.py`: Verifies og:title, og:image, og:type, og:site_name, and Twitter tags on front page, post pages, login page, and user profiles.

## Test plan
- [ ] CI tests pass
- [ ] Paste a link to the site in Discord/Slack/Twitter and verify the preview card renders correctly
- [ ] Check post links show post title and thumbnail in social previews
- [ ] Check user profile links show username and banner in social previews

Generated with [Claude Code](https://claude.com/claude-code)