### PR TITLE
fix: volunteer 'Click Here' opens in new tab (#460)

### DIFF
--- a/files/templates/volunteer_teaser.html
+++ b/files/templates/volunteer_teaser.html
@@ -5,7 +5,7 @@
         <div class="volunteer_text">
             <p class="header">The Motte Needs You!</p>
             <p class="text">If you have five minutes to help out, we'd like to hear your opinion on something.</p>
-            <p class="text">Click here!</p>
+            <p class="text">Click here! <a href="/volunteer" target="_blank" rel="noopener noreferrer">(open in new tab)</a></p>
         </div>
     </div>
 </a>

--- a/files/tests/test_volunteer.py
+++ b/files/tests/test_volunteer.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from . import util_accounts
 from . import util
 from . import util_submissions
@@ -168,3 +169,24 @@ def test_volunteer_submit_logged_out():
 	response = client.post("/volunteer/submit", data={})
 	# Should redirect to login or return 401/403
 	assert response.status_code in [302, 401, 403]
+
+
+def test_volunteer_teaser_open_in_new_tab():
+	"""Test that the volunteer teaser has an 'open in new tab' link (#460)"""
+	import os
+	template_path = os.path.join(
+		os.path.dirname(os.path.dirname(__file__)),
+		"templates", "volunteer_teaser.html"
+	)
+	with open(template_path, "r") as f:
+		html = f.read()
+
+	soup = BeautifulSoup(html, "html.parser")
+
+	# Find the nested link with target="_blank"
+	new_tab_link = soup.find("a", attrs={"target": "_blank"})
+	assert new_tab_link is not None, "Expected a link with target='_blank' in volunteer teaser"
+	assert new_tab_link.get("href") == "/volunteer"
+	assert "noopener" in new_tab_link.get("rel", [])
+	assert "noreferrer" in new_tab_link.get("rel", [])
+	assert "open in new tab" in new_tab_link.get_text().lower()


### PR DESCRIPTION
## Summary
- Fixes #460
- Volunteer janitor teaser "Click here!" text now includes "(open in new tab)" link with `target="_blank"`
- Clicking the banner itself still navigates in the same tab; the "(open in new tab)" portion opens `/volunteer` in a new tab
- Added `rel="noopener noreferrer"` for security

## Test plan
- [x] New test: `test_volunteer_teaser_open_in_new_tab` verifies link attributes (`target="_blank"`, `rel="noopener noreferrer"`, correct href and text)
- [x] All 11 existing volunteer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)