### PR TITLE
fix: enlarge collapse button click zone (#353)

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -4597,6 +4597,7 @@ video {
 	margin-left: 5px;
 	margin-right: 5px;
 	align-self: center;
+	position: relative;
 }
 .comment .comment-collapse-icon::before {
 	font-family: "font awesome 5 pro" !important;
@@ -4608,6 +4609,15 @@ video {
 	font-size: 14px;
 	font-weight: 900;
 	border: none;
+}
+.comment .comment-collapse-icon::after {
+	content: "";
+	position: absolute;
+	top: -10px;
+	left: -24px;
+	right: -8px;
+	bottom: -4px;
+	cursor: pointer;
 }
 .comment .comment-collapse-icon:hover::before {
 	color: var(--primary);


### PR DESCRIPTION
## Summary
- Fixes #353
- Comment collapse button click zone extended 24px to the left, 10px upward, 8px to the right, and 4px downward
- Visual appearance unchanged — the `-`/`+` icon renders identically
- Uses a `::after` pseudo-element with `position: absolute` on the collapse icon to create an invisible hit area that extends outside the icon's visible bounds

## Technical details
- Added `position: relative` to `.comment .comment-collapse-icon` to establish a positioning context
- Added `.comment .comment-collapse-icon::after` with absolute positioning and no visible content
- Clicks on the pseudo-element naturally bubble to the parent `div` which has the existing `onclick="collapse_comment(...)"` handler
- No JavaScript changes needed

## Test plan
- [ ] Visual check: collapse button `-`/`+` looks identical to before
- [ ] Click test: clicking in the area to the left of and above the button now triggers collapse
- [ ] Verify collapse/expand still works normally when clicking directly on the icon
- [ ] Check on mobile viewport (768px breakpoint) — icon margins are 0 at mobile, extended area still works
- [ ] Verify the collapse bar (vertical line below the icon) still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)