### PR TITLE
fix: wrap extremely long words in comment preview and body (#190)

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -3338,6 +3338,7 @@ small, .small {
 }
 .post-body {
 	word-break: break-word;
+	overflow-wrap: break-word;
 	overflow: hidden;
 	max-width: var(--text-width, 60em);
 }
@@ -3611,6 +3612,7 @@ small, .small {
 }
 .comment-body {
 	grid-area: comment-body;
+	min-width: 0;
 }
 #notifications .comment, #userpage .comment {
 	margin-top: 0.25rem;
@@ -3643,6 +3645,7 @@ small, .small {
 .comment .comment-body .comment-text {
 	margin-bottom: 1rem;
 	word-break: break-word;
+	overflow-wrap: break-word;
 	color: var(--black);
 	overflow: hidden;
 	padding-right: 10px !important;
@@ -5536,6 +5539,13 @@ div[id^="reply-edit-"] li > p:first-child {
   border: 1px dashed black;
   border-radius: 0.35em;
   padding: 0.375rem 0.75rem;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+.preview {
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .comment-section div[id^="form-preview-"] p.preview-msg, div[id^="reply-edit-"] p.preview-msg {

--- a/files/tests/test_css_word_wrap.py
+++ b/files/tests/test_css_word_wrap.py
@@ -1,0 +1,85 @@
+"""Tests that long-word wrapping CSS rules are present in main.css.
+
+Regression test for https://github.com/themotte/rDrama/issues/190:
+extremely long words (URLs, unbroken strings) must wrap in comment bodies,
+post bodies, and preview containers to prevent horizontal overflow.
+"""
+import os
+
+CSS_PATH = os.path.join(
+	os.path.dirname(__file__), "..", "assets", "css", "main.css"
+)
+
+
+def _read_css():
+	with open(CSS_PATH) as f:
+		return f.read()
+
+
+def _get_rule_block(css, selector):
+	"""Extract the content of a CSS rule block for the given selector.
+
+	Returns the text between { and the matching } for the first occurrence
+	of `selector` in the CSS. Returns None if not found.
+	"""
+	idx = css.find(selector)
+	if idx == -1:
+		return None
+	brace_start = css.find("{", idx)
+	if brace_start == -1:
+		return None
+	depth = 1
+	i = brace_start + 1
+	while i < len(css) and depth > 0:
+		if css[i] == "{":
+			depth += 1
+		elif css[i] == "}":
+			depth -= 1
+		i += 1
+	return css[brace_start + 1 : i - 1]
+
+
+def test_comment_text_has_word_break():
+	"""Comment text containers must wrap long words."""
+	css = _read_css()
+	block = _get_rule_block(css, ".comment .comment-body .comment-text")
+	assert block is not None, "selector .comment .comment-body .comment-text not found"
+	assert "word-break" in block
+	assert "overflow-wrap" in block
+
+
+def test_post_body_has_word_break():
+	"""Post body containers must wrap long words."""
+	css = _read_css()
+	block = _get_rule_block(css, ".post-body")
+	assert block is not None, "selector .post-body not found"
+	assert "word-break" in block
+	assert "overflow-wrap" in block
+
+
+def test_comment_body_has_min_width_zero():
+	"""Comment body grid item needs min-width: 0 to prevent grid overflow."""
+	css = _read_css()
+	block = _get_rule_block(css, ".comment-body {")
+	assert block is not None, "selector .comment-body not found"
+	assert "min-width" in block
+
+
+def test_form_preview_has_word_break():
+	"""Comment form preview containers must wrap long words."""
+	css = _read_css()
+	block = _get_rule_block(
+		css, '.comment-section div[id^="form-preview-"]'
+	)
+	assert block is not None, "form-preview selector not found"
+	assert "word-break" in block
+	assert "overflow-wrap" in block
+
+
+def test_preview_has_word_break():
+	"""Generic preview containers must wrap long words."""
+	css = _read_css()
+	block = _get_rule_block(css, ".preview {")
+	assert block is not None, "selector .preview not found"
+	assert "word-break" in block
+	assert "overflow-wrap" in block


### PR DESCRIPTION
## Summary
- Fixes #190
- Adds `overflow-wrap: break-word` to `.comment-text`, `.post-body`, form preview, and `.preview` containers
- Adds `min-width: 0` to `.comment-body` grid item to prevent CSS Grid overflow on mobile
- Existing `word-break: break-word` rules were already present on comment text and post body but insufficient alone for grid layout overflow; `overflow-wrap` provides cross-browser coverage and `min-width: 0` fixes the grid-level constraint
- Code blocks (`pre code`) already have `word-break: break-word` + `white-space: break-spaces` and are unaffected

## Changes
- `files/assets/css/main.css`: 4 targeted additions (10 new lines)
- `files/tests/test_css_word_wrap.py`: new regression test (5 test cases)

## Test plan
- [x] New test: 5 CSS rule assertions verify word-wrap properties are present
- [ ] Visual: long words/URLs wrap instead of overflowing container on mobile
- [ ] Code blocks still display correctly with existing break-spaces behavior
- [ ] No layout changes to navigation, buttons, or non-content areas

Generated with [Claude Code](https://claude.com/claude-code)