### PR TITLE
Enforce save relationship constraints (#468)

### DIFF
--- a/files/classes/comment.py
+++ b/files/classes/comment.py
@@ -74,6 +74,9 @@ class Comment(CreatedBase):
 		primaryjoin="CommentFlag.comment_id == Comment.id",
 		order_by="CommentFlag.created_datetimez",
 		viewonly=True)
+	saves = relationship("CommentSaveRelationship",
+		primaryjoin="CommentSaveRelationship.comment_id == Comment.id",
+		viewonly=True)
 	notes = relationship("UserNote", back_populates="comment")
 
 	def __repr__(self):

--- a/files/classes/saves.py
+++ b/files/classes/saves.py
@@ -6,16 +6,28 @@ from files.classes.base import Base
 class SaveRelationship(Base):
 	__tablename__ = "save_relationship"
 
-	user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
-	submission_id = Column(Integer, ForeignKey("submissions.id"), primary_key=True)
+	user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+	submission_id = Column(Integer, ForeignKey("submissions.id", ondelete="CASCADE"), primary_key=True)
 
 	Index('fki_save_relationship_submission_fkey', submission_id)
+
+	user = relationship("User", viewonly=True)
+	submission = relationship("Submission", viewonly=True)
+
+	def __repr__(self):
+		return f"<{self.__class__.__name__}(user_id={self.user_id}, submission_id={self.submission_id})>"
 
 
 class CommentSaveRelationship(Base):
 	__tablename__ = "comment_save_relationship"
 
-	user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
-	comment_id = Column(Integer, ForeignKey("comments.id"), primary_key=True)
+	user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+	comment_id = Column(Integer, ForeignKey("comments.id", ondelete="CASCADE"), primary_key=True)
 
 	Index('fki_comment_save_relationship_comment_fkey', comment_id)
+
+	user = relationship("User", viewonly=True)
+	comment = relationship("Comment", viewonly=True)
+
+	def __repr__(self):
+		return f"<{self.__class__.__name__}(user_id={self.user_id}, comment_id={self.comment_id})>"

--- a/files/classes/submission.py
+++ b/files/classes/submission.py
@@ -80,6 +80,7 @@ class Submission(CreatedBase):
 	oauth_app = relationship("OauthApp", viewonly=True)
 	awards = relationship("AwardRelationship", viewonly=True)
 	reports = relationship("Flag", viewonly=True)
+	saves = relationship("SaveRelationship", viewonly=True)
 	comments = relationship("Comment", primaryjoin="Comment.parent_submission==Submission.id")
 	notes = relationship("UserNote", back_populates="post")
 	task = relationship("ScheduledSubmissionTask", back_populates="submissions")

--- a/files/tests/test_save_relationships.py
+++ b/files/tests/test_save_relationships.py
@@ -1,0 +1,220 @@
+"""Tests for save relationship enforcement (issue #468).
+
+Verifies that SaveRelationship and CommentSaveRelationship models have
+proper ORM relationships and that the saved_idlist/saved_comment_idlist
+methods correctly filter deleted/removed content.
+"""
+from . import util_accounts
+from . import util
+from . import util_submissions
+from . import util_comments
+
+
+def test_save_relationship_has_orm_relationships():
+	"""Test that SaveRelationship has user and submission relationships"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+
+	from files.__main__ import db_session
+	from files.classes import SaveRelationship
+
+	# Save the post
+	save_response, _ = util.post_with_formkey(client, f"/save_post/{post.id}", data={})
+	assert save_response.status_code == 200
+
+	# Query the save and verify ORM relationships
+	save = db_session.query(SaveRelationship).filter_by(
+		user_id=user.id, submission_id=post.id
+	).one()
+	assert save.user is not None
+	assert save.user.id == user.id
+	assert save.submission is not None
+	assert save.submission.id == post.id
+
+
+def test_comment_save_relationship_has_orm_relationships():
+	"""Test that CommentSaveRelationship has user and comment relationships"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+	comment = util_comments.create_comment_for_client(client, post.id)
+
+	from files.__main__ import db_session
+	from files.classes import CommentSaveRelationship
+
+	# Save the comment
+	save_response, _ = util.post_with_formkey(client, f"/save_comment/{comment.id}", data={})
+	assert save_response.status_code == 200
+
+	# Query the save and verify ORM relationships
+	save = db_session.query(CommentSaveRelationship).filter_by(
+		user_id=user.id, comment_id=comment.id
+	).one()
+	assert save.user is not None
+	assert save.user.id == user.id
+	assert save.comment is not None
+	assert save.comment.id == comment.id
+
+
+def test_submission_has_saves_relationship():
+	"""Test that Submission model has a saves relationship"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+
+	from files.__main__ import db_session
+	from files.classes import Submission
+
+	# Save the post
+	save_response, _ = util.post_with_formkey(client, f"/save_post/{post.id}", data={})
+	assert save_response.status_code == 200
+
+	# Check the saves relationship on the submission
+	db_session.expire_all()
+	submission = db_session.query(Submission).filter_by(id=post.id).one()
+	assert hasattr(submission, 'saves')
+	assert len(submission.saves) == 1
+	assert submission.saves[0].user_id == user.id
+
+
+def test_comment_has_saves_relationship():
+	"""Test that Comment model has a saves relationship"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+	comment = util_comments.create_comment_for_client(client, post.id)
+
+	from files.__main__ import db_session
+	from files.classes import Comment
+
+	# Save the comment
+	save_response, _ = util.post_with_formkey(client, f"/save_comment/{comment.id}", data={})
+	assert save_response.status_code == 200
+
+	# Check the saves relationship on the comment
+	db_session.expire_all()
+	db_comment = db_session.query(Comment).filter_by(id=comment.id).one()
+	assert hasattr(db_comment, 'saves')
+	assert len(db_comment.saves) == 1
+	assert db_comment.saves[0].user_id == user.id
+
+
+def test_saved_idlist_excludes_deleted_posts():
+	"""Test that saved_idlist filters out user-deleted posts"""
+	client, user = util_accounts.create_test_client_and_user()
+
+	# Create and save two posts
+	post1 = util_submissions.create_submission_for_client(client)
+	post2 = util_submissions.create_submission_for_client(client)
+
+	save1, _ = util.post_with_formkey(client, f"/save_post/{post1.id}", data={})
+	assert save1.status_code == 200
+	save2, _ = util.post_with_formkey(client, f"/save_post/{post2.id}", data={})
+	assert save2.status_code == 200
+
+	from files.__main__ import db_session
+	from files.classes import User
+	db_session.expire_all()
+
+	# Both posts should appear in saved list
+	user_fresh = db_session.query(User).filter_by(id=user.id).one()
+	saved_ids = user_fresh.saved_idlist()
+	assert post1.id in saved_ids
+	assert post2.id in saved_ids
+
+	# Delete post1
+	delete_response, _ = util.post_with_formkey(client, f"/delete_post/{post1.id}", data={})
+	assert delete_response.status_code == 200
+
+	# post1 should no longer appear in saved list
+	db_session.expire_all()
+	user_fresh = db_session.query(User).filter_by(id=user.id).one()
+	saved_ids = user_fresh.saved_idlist()
+	assert post1.id not in saved_ids
+	assert post2.id in saved_ids
+
+
+def test_saved_comment_idlist_excludes_deleted_comments():
+	"""Test that saved_comment_idlist filters out user-deleted comments"""
+	client, user = util_accounts.create_test_client_and_user()
+	post = util_submissions.create_submission_for_client(client)
+
+	# Create and save two comments
+	comment1 = util_comments.create_comment_for_client(client, post.id)
+	comment2 = util_comments.create_comment_for_client(client, post.id)
+
+	save1, _ = util.post_with_formkey(client, f"/save_comment/{comment1.id}", data={})
+	assert save1.status_code == 200
+	save2, _ = util.post_with_formkey(client, f"/save_comment/{comment2.id}", data={})
+	assert save2.status_code == 200
+
+	from files.__main__ import db_session
+	from files.classes import User
+	db_session.expire_all()
+
+	# Both comments should appear in saved list
+	user_fresh = db_session.query(User).filter_by(id=user.id).one()
+	saved_ids = user_fresh.saved_comment_idlist()
+	assert comment1.id in saved_ids
+	assert comment2.id in saved_ids
+
+	# Delete comment1
+	delete_response, _ = util.post_with_formkey(
+		client, f"/delete/comment/{comment1.id}", data={}
+	)
+	assert delete_response.status_code == 200
+
+	# comment1 should no longer appear in saved list
+	db_session.expire_all()
+	user_fresh = db_session.query(User).filter_by(id=user.id).one()
+	saved_ids = user_fresh.saved_comment_idlist()
+	assert comment1.id not in saved_ids
+	assert comment2.id in saved_ids
+
+
+def test_saved_idlist_excludes_blocked_user_posts():
+	"""Test that saved_idlist filters out posts by blocked users"""
+	client1, user1 = util_accounts.create_test_client_and_user("saver-blk")
+	client2, user2 = util_accounts.create_test_client_and_user("author-blk")
+
+	# User2 creates a post
+	post = util_submissions.create_submission_for_client(client2)
+
+	# User1 saves user2's post
+	save_response, _ = util.post_with_formkey(client1, f"/save_post/{post.id}", data={})
+	assert save_response.status_code == 200
+
+	from files.__main__ import db_session
+	from files.classes import User
+	db_session.expire_all()
+
+	# Post should appear in user1's saved list
+	user1_fresh = db_session.query(User).filter_by(id=user1.id).one()
+	saved_ids = user1_fresh.saved_idlist()
+	assert post.id in saved_ids
+
+	# User1 blocks user2
+	block_response, _ = util.post_with_formkey(client1, f"/settings/block", data={
+		"username": user2.username
+	})
+	# Block may use a different endpoint; check for the block relationship directly
+	from files.classes import UserBlock
+	block = UserBlock(user_id=user1.id, target_id=user2.id)
+	db_session.add(block)
+	db_session.commit()
+
+	# Post by blocked user should no longer appear in saved list
+	db_session.expire_all()
+	user1_fresh = db_session.query(User).filter_by(id=user1.id).one()
+	saved_ids = user1_fresh.saved_idlist()
+	assert post.id not in saved_ids
+
+
+def test_save_relationship_repr():
+	"""Test that save relationship models have meaningful repr"""
+	from files.classes import SaveRelationship, CommentSaveRelationship
+
+	save = SaveRelationship(user_id=1, submission_id=2)
+	assert "user_id=1" in repr(save)
+	assert "submission_id=2" in repr(save)
+
+	comment_save = CommentSaveRelationship(user_id=3, comment_id=4)
+	assert "user_id=3" in repr(comment_save)
+	assert "comment_id=4" in repr(comment_save)

--- a/migrations/versions/2026_02_26_12_00_00_2674d1a660a4_enforce_save_relationship_cascades.py
+++ b/migrations/versions/2026_02_26_12_00_00_2674d1a660a4_enforce_save_relationship_cascades.py
@@ -1,0 +1,86 @@
+"""Enforce save relationship cascades
+
+Add ON DELETE CASCADE to save_relationship and comment_save_relationship
+foreign keys so that saves are automatically cleaned up when the referenced
+user, submission, or comment is deleted.
+
+Fixes https://github.com/themotte/rDrama/issues/468
+
+Revision ID: 2674d1a660a4
+Revises: 2481e3a04265
+Create Date: 2026-02-26 12:00:00.000000+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2674d1a660a4'
+down_revision = '2481e3a04265'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+	# Drop existing FK constraints (no cascade) and recreate with ON DELETE CASCADE
+
+	# save_relationship: submission_id -> submissions.id
+	op.drop_constraint('save_relationship_submission_fkey', 'save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'save_relationship_submission_fkey', 'save_relationship',
+		'submissions', ['submission_id'], ['id'], ondelete='CASCADE'
+	)
+
+	# save_relationship: user_id -> users.id
+	op.drop_constraint('save_relationship_user_fkey', 'save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'save_relationship_user_fkey', 'save_relationship',
+		'users', ['user_id'], ['id'], ondelete='CASCADE'
+	)
+
+	# comment_save_relationship: comment_id -> comments.id
+	op.drop_constraint('comment_save_relationship_comment_fkey', 'comment_save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'comment_save_relationship_comment_fkey', 'comment_save_relationship',
+		'comments', ['comment_id'], ['id'], ondelete='CASCADE'
+	)
+
+	# comment_save_relationship: user_id -> users.id
+	op.drop_constraint('comment_save_relationship_user_fkey', 'comment_save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'comment_save_relationship_user_fkey', 'comment_save_relationship',
+		'users', ['user_id'], ['id'], ondelete='CASCADE'
+	)
+
+
+def downgrade():
+	# Revert to original FK constraints without ON DELETE CASCADE
+
+	# comment_save_relationship: user_id -> users.id
+	op.drop_constraint('comment_save_relationship_user_fkey', 'comment_save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'comment_save_relationship_user_fkey', 'comment_save_relationship',
+		'users', ['user_id'], ['id']
+	)
+
+	# comment_save_relationship: comment_id -> comments.id
+	op.drop_constraint('comment_save_relationship_comment_fkey', 'comment_save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'comment_save_relationship_comment_fkey', 'comment_save_relationship',
+		'comments', ['comment_id'], ['id']
+	)
+
+	# save_relationship: user_id -> users.id
+	op.drop_constraint('save_relationship_user_fkey', 'save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'save_relationship_user_fkey', 'save_relationship',
+		'users', ['user_id'], ['id']
+	)
+
+	# save_relationship: submission_id -> submissions.id
+	op.drop_constraint('save_relationship_submission_fkey', 'save_relationship', type_='foreignkey')
+	op.create_foreign_key(
+		'save_relationship_submission_fkey', 'save_relationship',
+		'submissions', ['submission_id'], ['id']
+	)


### PR DESCRIPTION
## Summary
- Fixes #468
- Adds `ON DELETE CASCADE` to all four foreign keys on `save_relationship` and `comment_save_relationship` tables via Alembic migration, so saves are automatically cleaned up when the referenced user, submission, or comment is deleted
- Adds ORM `relationship()` attributes to `SaveRelationship` and `CommentSaveRelationship` models (user, submission/comment), matching the existing pattern used by `Flag`/`CommentFlag`
- Adds `saves` back-reference relationship on `Submission` and `Comment` models, matching the existing `reports` pattern
- Adds `__repr__` to both save models for debuggability
- The `sub_block` portion of #468 was already resolved when holes were removed (migration `6b6c1b21a487`)

## Details

The save models previously defined `ForeignKey` constraints but:
1. Had no `ON DELETE CASCADE` -- deleting a user/post/comment could leave orphaned save rows or fail with FK violations
2. Had no SQLAlchemy `relationship()` attributes -- the ORM had no way to navigate from a save to its user/submission/comment or vice versa
3. Parent models (`Submission`, `Comment`) had no `saves` relationship -- unlike `reports` which had proper back-references

## Test plan
- [x] New test: `test_save_relationship_has_orm_relationships` -- verifies ORM navigation from save to user/submission
- [x] New test: `test_comment_save_relationship_has_orm_relationships` -- verifies ORM navigation from save to user/comment
- [x] New test: `test_submission_has_saves_relationship` -- verifies `Submission.saves` back-reference
- [x] New test: `test_comment_has_saves_relationship` -- verifies `Comment.saves` back-reference
- [x] New test: `test_saved_idlist_excludes_deleted_posts` -- verifies deleted posts filtered from saved list
- [x] New test: `test_saved_comment_idlist_excludes_deleted_comments` -- verifies deleted comments filtered from saved list
- [x] New test: `test_saved_idlist_excludes_blocked_user_posts` -- verifies blocked user posts filtered from saved list
- [x] New test: `test_save_relationship_repr` -- verifies meaningful repr on both models
- [ ] Existing save/unsave tests continue to pass
- [ ] Migration applies cleanly on a database with existing save rows

## Note for Reviewer

The migration drops and recreates foreign key constraints by name (e.g., `save_relationship_submission_fkey`). These names were derived from the index names visible in the schema (`fki_save_relationship_submission_fkey`), but if the actual constraint names differ in production, the migration will fail safely (no data loss). To verify before merging:

```sql
SELECT conname FROM pg_constraint 
WHERE conrelid = 'save_relationship'::regclass AND contype = 'f';
```

If names don't match, I'll update the migration immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)