### PR TITLE
fix: make 'Open External Links In New Tabs' consistent (#322)

### DIFF
--- a/files/helpers/content.py
+++ b/files/helpers/content.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+import re
 import urllib.parse
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -49,6 +50,66 @@ def canonicalize_url2(url:str, *, httpsify:bool=False) -> urllib.parse.ParseResu
 	return url_parsed
 
 
+def _is_external_link(href:str) -> bool:
+	"""Check if a link is external (not to this site)."""
+	from files.helpers.config.environment import SITE_FULL
+	if not href:
+		return False
+	if href.startswith('/'):
+		return False
+	if href.startswith(f'{SITE_FULL}/'):
+		return False
+	if href.startswith('#'):
+		return False
+	return True
+
+
+# Regex to match <a ...> tags. We use a non-greedy match on the attributes.
+_A_TAG_RE = re.compile(r'(<a\s)(.*?)(>)', re.DOTALL | re.IGNORECASE)
+_TARGET_BLANK_RE = re.compile(r'\s*target\s*=\s*"_blank"\s*', re.IGNORECASE)
+_HREF_RE = re.compile(r'href\s*=\s*"([^"]*)"', re.IGNORECASE)
+
+
+def _apply_newtab_settings(body:str, newtab:bool, newtabexternal:bool) -> str:
+	"""
+	Adjust target="_blank" on links in rendered HTML body content
+	based on the viewing user's newtab/newtabexternal settings.
+
+	The sanitizer always adds target="_blank" to external links at
+	content-creation time. This function corrects that per-viewer:
+	- If newtabexternal is False, remove target="_blank" from external links
+	- If newtab is True, add target="_blank" to internal links
+	"""
+	# Default settings (newtab=False, newtabexternal=True) match what the
+	# sanitizer already does, so we can skip processing entirely.
+	if not newtab and newtabexternal:
+		return body
+
+	def _replace_a_tag(match):
+		prefix = match.group(1)  # '<a '
+		attrs = match.group(2)   # everything between '<a ' and '>'
+		suffix = match.group(3)  # '>'
+
+		href_match = _HREF_RE.search(attrs)
+		if not href_match:
+			return match.group(0)
+
+		href = href_match.group(1)
+		is_external = _is_external_link(href)
+		has_target_blank = _TARGET_BLANK_RE.search(attrs)
+
+		if is_external and not newtabexternal and has_target_blank:
+			# Remove target="_blank" from external links
+			attrs = _TARGET_BLANK_RE.sub(' ', attrs).strip()
+		elif not is_external and newtab and not has_target_blank:
+			# Add target="_blank" to internal links
+			attrs = f'{attrs} target="_blank"'
+
+		return f'{prefix}{attrs}{suffix}'
+
+	return _A_TAG_RE.sub(_replace_a_tag, body)
+
+
 def body_displayed(target:Submittable, v:Optional[User], is_html:bool) -> str:
 	added_message = target.visibility_state.added_message(v)
 
@@ -68,8 +129,12 @@ def body_displayed(target:Submittable, v:Optional[User], is_html:bool) -> str:
 			body = f'{body}\n\n{added_message}'
 
 	body = body.replace("old.reddit.com", v.reddit)
-	if v.nitter and '/i/' not in body and '/retweets' not in body: 
+	if v.nitter and '/i/' not in body and '/retweets' not in body:
 		body = body.replace("www.twitter.com", "nitter.net").replace("twitter.com", "nitter.net")
+
+	if is_html:
+		body = _apply_newtab_settings(body, v.newtab, v.newtabexternal)
+
 	return body
 
 

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -173,7 +173,7 @@
 
             {% endif %}
 						<span data-bs-toggle="tooltip" data-bs-placement="bottom" id="timestamp" onmouseover="timestamp('timestamp','{{p.created_utc}}')">&nbsp;{{p.age_string}}</span>
-						({% if p.is_image %}image post{% elif p.is_video %}video post{% elif p.domain %}<a href="/search/posts/?q=domain%3A{{p.domain}}&sort=new&t=all" class="post-meta-domain" {% if not v or v.newtabexternal %}target="_blank"{% endif %}>{{p.domain|truncate(35, True)}}</a>{% else %}text post{% endif %})
+						({% if p.is_image %}image post{% elif p.is_video %}video post{% elif p.domain %}<a href="/search/posts/?q=domain%3A{{p.domain}}&sort=new&t=all" class="post-meta-domain" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>{{p.domain|truncate(35, True)}}</a>{% else %}text post{% endif %})
 
 						{% if p.edited_utc %}
 							&nbsp;&nbsp;Edited <span data-bs-toggle="tooltip" data-bs-placement="bottom" onmouseover="timestamp('edited_timestamp','{{p.edited_utc}}')" id="edited_timestamp">{{p.edited_string}}</span>

--- a/files/tests/test_newtab_links.py
+++ b/files/tests/test_newtab_links.py
@@ -1,0 +1,177 @@
+"""Tests for newtab link handling in content body display.
+
+Covers the _is_external_link and _apply_newtab_settings functions in
+files/helpers/content.py, which ensure the user's "Open External Links
+In New Tabs" and "Open Internal Links In New Tabs" settings are applied
+consistently to links inside rendered post/comment bodies.
+"""
+
+import pytest
+
+
+class TestIsExternalLink:
+	"""Tests for _is_external_link helper."""
+
+	def test_empty_href(self):
+		from files.helpers.content import _is_external_link
+		assert _is_external_link("") is False
+		assert _is_external_link(None) is False
+
+	def test_relative_path_is_internal(self):
+		from files.helpers.content import _is_external_link
+		assert _is_external_link("/post/123") is False
+		assert _is_external_link("/search/posts/") is False
+
+	def test_site_full_url_is_internal(self):
+		from files.helpers.content import _is_external_link
+		from files.helpers.config.environment import SITE_FULL
+		assert _is_external_link(f"{SITE_FULL}/post/123") is False
+
+	def test_fragment_is_internal(self):
+		from files.helpers.content import _is_external_link
+		assert _is_external_link("#section") is False
+
+	def test_external_http_url(self):
+		from files.helpers.content import _is_external_link
+		assert _is_external_link("https://example.com") is True
+
+	def test_external_different_domain(self):
+		from files.helpers.content import _is_external_link
+		assert _is_external_link("https://old.reddit.com/r/test") is True
+
+	def test_external_no_scheme(self):
+		from files.helpers.content import _is_external_link
+		# URLs without scheme but with domain are external
+		assert _is_external_link("example.com") is True
+
+
+class TestApplyNewtabSettings:
+	"""Tests for _apply_newtab_settings function."""
+
+	def test_default_settings_no_change(self):
+		"""Default settings (newtab=False, newtabexternal=True) should not modify body."""
+		from files.helpers.content import _apply_newtab_settings
+		body = '<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">link</a>'
+		result = _apply_newtab_settings(body, newtab=False, newtabexternal=True)
+		assert result == body
+
+	def test_newtabexternal_false_removes_target_blank(self):
+		"""When newtabexternal=False, target="_blank" should be removed from external links."""
+		from files.helpers.content import _apply_newtab_settings
+		body = '<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">link</a>'
+		result = _apply_newtab_settings(body, newtab=False, newtabexternal=False)
+		assert 'target="_blank"' not in result
+		assert 'href="https://example.com"' in result
+		assert 'rel="nofollow noopener noreferrer"' in result
+
+	def test_newtabexternal_false_preserves_internal_links(self):
+		"""When newtabexternal=False, internal links should not be affected."""
+		from files.helpers.content import _apply_newtab_settings
+		body = '<a href="/post/123">internal link</a>'
+		result = _apply_newtab_settings(body, newtab=False, newtabexternal=False)
+		assert 'target="_blank"' not in result
+
+	def test_newtab_true_adds_target_blank_to_internal(self):
+		"""When newtab=True, target="_blank" should be added to internal links."""
+		from files.helpers.content import _apply_newtab_settings
+		body = '<a href="/post/123">internal link</a>'
+		result = _apply_newtab_settings(body, newtab=True, newtabexternal=True)
+		assert 'target="_blank"' in result
+
+	def test_newtab_true_does_not_duplicate_target_blank(self):
+		"""When newtab=True, should not add duplicate target="_blank" to links that already have it."""
+		from files.helpers.content import _apply_newtab_settings
+		body = '<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">link</a>'
+		result = _apply_newtab_settings(body, newtab=True, newtabexternal=True)
+		assert result.count('target="_blank"') == 1
+
+	def test_both_settings_off(self):
+		"""With newtab=False, newtabexternal=False, no links should have target="_blank"."""
+		from files.helpers.content import _apply_newtab_settings
+		body = (
+			'<a href="/post/123">internal</a> '
+			'<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">external</a>'
+		)
+		result = _apply_newtab_settings(body, newtab=False, newtabexternal=False)
+		assert 'target="_blank"' not in result
+
+	def test_both_settings_on(self):
+		"""With newtab=True, newtabexternal=True, all links should have target="_blank"."""
+		from files.helpers.content import _apply_newtab_settings
+		body = (
+			'<a href="/post/123">internal</a> '
+			'<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">external</a>'
+		)
+		result = _apply_newtab_settings(body, newtab=True, newtabexternal=True)
+		# Both links should have target="_blank"
+		assert result.count('target="_blank"') == 2
+
+	def test_mixed_links_default_external_only(self):
+		"""Default settings: only external links have target="_blank"."""
+		from files.helpers.content import _apply_newtab_settings
+		body = (
+			'<a href="/post/123">internal</a> '
+			'<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">external</a>'
+		)
+		result = _apply_newtab_settings(body, newtab=False, newtabexternal=True)
+		# Should be unchanged from input
+		assert result == body
+
+	def test_newtab_true_newtabexternal_false(self):
+		"""newtab=True, newtabexternal=False: internal links open in new tab, external don't."""
+		from files.helpers.content import _apply_newtab_settings
+		body = (
+			'<a href="/post/123">internal</a> '
+			'<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">external</a>'
+		)
+		result = _apply_newtab_settings(body, newtab=True, newtabexternal=False)
+		# Only 1 target="_blank" -- on the internal link
+		assert result.count('target="_blank"') == 1
+		# Verify it's on the internal link, not the external one
+		assert '/post/123" target="_blank"' in result
+
+	def test_multiple_external_links(self):
+		"""Multiple external links should all be handled."""
+		from files.helpers.content import _apply_newtab_settings
+		body = (
+			'<a href="https://example.com" target="_blank" rel="nofollow noopener noreferrer">one</a> '
+			'<a href="https://other.org" target="_blank" rel="nofollow noopener noreferrer">two</a>'
+		)
+		result = _apply_newtab_settings(body, newtab=False, newtabexternal=False)
+		assert 'target="_blank"' not in result
+
+	def test_links_without_href_unchanged(self):
+		"""Anchor tags without href should not be modified."""
+		from files.helpers.content import _apply_newtab_settings
+		body = '<a name="anchor">section</a>'
+		result = _apply_newtab_settings(body, newtab=True, newtabexternal=False)
+		assert result == body
+
+	def test_preserves_surrounding_html(self):
+		"""Non-link HTML should be preserved."""
+		from files.helpers.content import _apply_newtab_settings
+		body = '<p>Hello <strong>world</strong></p><a href="https://example.com" target="_blank">link</a><p>end</p>'
+		result = _apply_newtab_settings(body, newtab=False, newtabexternal=False)
+		assert '<p>Hello <strong>world</strong></p>' in result
+		assert '<p>end</p>' in result
+		assert 'target="_blank"' not in result
+
+	def test_site_full_url_treated_as_internal(self):
+		"""Links using the full site URL should be treated as internal."""
+		from files.helpers.content import _apply_newtab_settings
+		from files.helpers.config.environment import SITE_FULL
+		body = f'<a href="{SITE_FULL}/post/123">site link</a>'
+		result = _apply_newtab_settings(body, newtab=True, newtabexternal=True)
+		assert 'target="_blank"' in result
+
+	def test_empty_body(self):
+		"""Empty body should be returned as-is."""
+		from files.helpers.content import _apply_newtab_settings
+		assert _apply_newtab_settings("", newtab=True, newtabexternal=False) == ""
+
+	def test_body_without_links(self):
+		"""Body without links should be returned as-is."""
+		from files.helpers.content import _apply_newtab_settings
+		body = "<p>Just some text with no links</p>"
+		result = _apply_newtab_settings(body, newtab=True, newtabexternal=False)
+		assert result == body


### PR DESCRIPTION
## Summary
- Fixes #322
- The "Open External Links In New Tabs" (`newtabexternal`) setting now applies consistently to **all** external links, including those inside post/comment body content
- **Root cause**: The sanitizer (`sanitize.py`) always added `target="_blank"` to external links at content-creation time, storing it in `body_html`. The viewing user's `newtabexternal` preference was never consulted for these stored links -- only for template-rendered links (submission URLs, thumbnails, etc.)
- **Fix**: Added per-viewer `target="_blank"` adjustment in `body_displayed()` (in `content.py`), which already handles other per-viewer content transformations (reddit URL replacement, nitter). When `newtabexternal=False`, strips `target="_blank"` from external links in body HTML. When `newtab=True`, adds `target="_blank"` to internal links
- **Performance**: Default settings (`newtab=False`, `newtabexternal=True`) match what the sanitizer already does, so the regex processing is skipped entirely for the common case -- zero overhead
- **Template fix**: Also fixed `submission.html` where an internal domain search link (`/search/posts/...`) incorrectly used `newtabexternal` instead of `newtab`

## Test plan
- [x] New tests: 22 test cases covering all combinations of `newtab`/`newtabexternal` settings
- [x] External links in post/comment bodies respect `newtabexternal=False` (target removed)
- [x] External links in post/comment bodies respect `newtabexternal=True` (target kept)
- [x] Internal links in post/comment bodies respect `newtab=True` (target added)
- [x] Internal links are NOT affected by `newtabexternal` setting
- [x] Links without href are not modified
- [x] Non-link HTML is preserved
- [x] No duplicate `target="_blank"` attributes
- [x] Empty/linkless body content handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)