### PR TITLE
Feat/link button in comment editor

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -3751,6 +3751,7 @@ ul.comment-section {
 }
 .comment-format {
 	display: flex;
+	gap: 4px;
 	align-items: center;
 	bottom: 0;
 	left: 0;

--- a/files/assets/js/formatting.js
+++ b/files/assets/js/formatting.js
@@ -60,7 +60,13 @@
 				return line.substring(line.indexOf('>') + 1);
 			}).join('\n');
 	});
+	var link = select(function(selection) {
+		return `[${selection}]()`;
+	});
+
 	makeItalics = wrap(enclose('*'));
 	makeBold = wrap(enclose('**'));
 	makeQuote = wrap(quote);
+	makeLink = wrap(link);
+
 })()

--- a/files/assets/js/formatting.js
+++ b/files/assets/js/formatting.js
@@ -1,5 +1,5 @@
 (function() {
-	var event = InputEvent
+	const event = InputEvent
 		? function(type, attrs) {
 			return new InputEvent(type, attrs);
 		}
@@ -8,61 +8,65 @@
 			e.initEvent(type, false, false);
 			return e;
 		};
-	var escape = function(str) {
-		return str.replace(/./g, '[$&]').replace(/[\\^]|]]/g, '\\$&');
-	};
-	var wrap = function(cb) {
-		return function(id) {
-			var form = document.getElementById(id);
-			if (cb(form)) {
-				var e = event('input', { inputType: 'insertReplacementText' });
+
+	const escape = (str) => (
+		str.replace(/./g, '[$&]').replace(/[\\^]|]]/g, '\\$&')
+	);
+
+	const wrap = (callback) => (
+		(id) => {
+			const form = document.getElementById(id);
+			if (callback(form)) {
+				const e = event('input', { inputType: 'insertReplacementText' });
 				form.dispatchEvent(e);
 			}
 		}
-	};
-	var select = function(cb) {
-		return function(form) {
-			var begin = form.selectionStart, end = form.selectionEnd;
+	);
+
+	const select = (callback) => (
+		(form) => {
+			const begin = form.selectionStart, end = form.selectionEnd;
 			if (begin == end)
 				return false;
 			form.value = form.value.substring(0, begin)
-				+ cb(form.value.substring(begin, end))
+				+ callback(form.value.substring(begin, end))
 				+ form.value.substring(end);
 			return true;
-		};
-	};
-	var enclose = function(mark) {
-		var re = (function() {
-			var pat = escape(mark);
+		}
+	);
+
+	const enclose = (mark) => {
+		const re = (() => {
+			const pat = escape(mark);
 			return new RegExp(pat + '(\\S([^](?!\\s' + pat + '\\S))*?\\S|\\S)' + pat, 'g');
 		})();
-		return select(function(selection) {
-			return selection.replace(/[^]*?(?=\n{2,})|[^]*/g, function(selection) {
-				var replacement = selection.replace(re, '$1');
+		return select((selection) => (
+			selection.replace(/[^]*?(?=\n{2,})|[^]*/g, (selection) => {
+				let replacement = selection.replace(re, '$1');
 				for (var old = Infinity;
 				     replacement.length < old;
 				     replacement = replacement.replace(re, '$1'))
 					old = replacement.length;
 				if (replacement.length == selection.length)
-					replacement = replacement.replace(/\S[^]*\S|\S/, function (str) {
+					replacement = replacement.replace(/\S[^]*\S|\S/, (str) => {
 						return mark + str + mark;
-					});
+					})
 				return replacement;
-			});
-		});
+			})
+		));
 	};
-	var quote = select(function(selection) {
-		var lines = selection.split('\n');
-		if (lines.some(function(line) { return /^\s*[^\s>]/.test(line) }))
+
+	const quote = select((selection) => {
+		const lines = selection.split('\n');
+		if (lines.some((line) => /^\s*[^\s>]/.test(line)))
 			return '>' + lines.join('\n>');
 		else
-			return lines.map(function(line) {
-				return line.substring(line.indexOf('>') + 1);
-			}).join('\n');
+			return lines.map(
+				(line) => line.substring(line.indexOf('>') + 1)
+			).join('\n');
 	});
-	var link = select(function(selection) {
-		return `[${selection}]()`;
-	});
+
+	const link = select((selection) => `[${selection}]()`);
 
 	makeItalics = wrap(enclose('*'));
 	makeBold = wrap(enclose('**'));

--- a/files/templates/component/comment/editbox_comment.html
+++ b/files/templates/component/comment/editbox_comment.html
@@ -17,6 +17,8 @@
 					<div id="filename-edit-reply-{{c.id}}"><i class="far fa-image"></i></div>
 						<input autocomplete="off" id="file-edit-reply-{{c.id}}" type="file" multiple="multiple" name="file" accept="image\/*, video\/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-edit-reply-{{c.id}}','file-edit-reply-{{c.id}}')" hidden>
 				</label>
+				&nbsp;
+				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 			</div>
 			<a id="edit-btn-{{c.id}}" role="button" form="comment-edit-form-{{c.id}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="comment_edit('{{c.id}}')">Save Edit</a> 
 			<a id="cancel-edit-{{c.id}}" role="button" onclick="toggleEdit('{{c.id}}')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 

--- a/files/templates/component/comment/editbox_comment.html
+++ b/files/templates/component/comment/editbox_comment.html
@@ -6,19 +6,14 @@
 			<div class="text-small font-weight-bold mt-1" id="charcount-edit-{{c.id}}" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 			<div class="comment-format">
 				<a class="btn btn-secondary format m-0" role="button" onclick="makeBold('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold"><i class="fas fa-bold"></i></a>
-				&nbsp;
 				<a class="btn btn-secondary format m-0" role="button" onclick="makeItalics('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize"><i class="fas fa-italic"></i></a>
-				&nbsp;
 				<a class="btn btn-secondary format m-0" role="button" onclick="makeQuote('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote"><i class="fas fa-quote-right"></i></a>
-				&nbsp;
 				<small class="btn btn-secondary format m-0" aria-hidden="true" onclick="commentForm('comment-edit-body-{{c.id}}');getGif()" data-bs-toggle="modal" data-bs-target="#gifModal" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Add GIF"><span class="font-weight-bolder text-uppercase">GIF</span></small>
-				&nbsp;
+				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 				<label class="btn btn-secondary format m-0" for="file-edit-reply-{{c.id}}">
 					<div id="filename-edit-reply-{{c.id}}"><i class="far fa-image"></i></div>
 						<input autocomplete="off" id="file-edit-reply-{{c.id}}" type="file" multiple="multiple" name="file" accept="image\/*, video\/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-edit-reply-{{c.id}}','file-edit-reply-{{c.id}}')" hidden>
 				</label>
-				&nbsp;
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 			</div>
 			<a id="edit-btn-{{c.id}}" role="button" form="comment-edit-form-{{c.id}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="comment_edit('{{c.id}}')">Save Edit</a> 
 			<a id="cancel-edit-{{c.id}}" role="button" onclick="toggleEdit('{{c.id}}')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 

--- a/files/templates/component/comment/replybox_comment.html
+++ b/files/templates/component/comment/replybox_comment.html
@@ -10,17 +10,13 @@
 
 			<div class="comment-format" id="comment-format-bar-{{c.id}}"> 
 				<a class="btn btn-secondary format m-0" role="button" onclick="makeBold('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold"><i class="fas fa-bold"></i></a>
-				&nbsp;
 				<a class="btn btn-secondary format m-0" role="button" onclick="makeItalics('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize"><i class="fas fa-italic"></i></a>
-				&nbsp;
 				<a class="btn btn-secondary format m-0" role="button" onclick="makeQuote('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote"><i class="fas fa-quote-right"></i></a>
-				&nbsp;
+				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 				<label class="btn btn-secondary format m-0" for="file-upload-reply-{{c.fullname}}">
 					<div id="filename-show-reply-{{c.fullname}}"><i class="far fa-image"></i></div>
 					<input autocomplete="off" id="file-upload-reply-{{c.fullname}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-reply-{{c.fullname}}','file-upload-reply-{{c.fullname}}')" hidden>
 				</label>
-				&nbsp;
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 			</div>
 			<a id="save-reply-to-{{c.fullname}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="post_comment('{{c.fullname}}', '{{c.post.id}}', {{level}})"role="button">Comment</a>
 			<a role="button" onclick="document.getElementById('reply-to-{{c.id}}').classList.add('d-none')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 

--- a/files/templates/component/comment/replybox_comment.html
+++ b/files/templates/component/comment/replybox_comment.html
@@ -19,6 +19,8 @@
 					<div id="filename-show-reply-{{c.fullname}}"><i class="far fa-image"></i></div>
 					<input autocomplete="off" id="file-upload-reply-{{c.fullname}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-reply-{{c.fullname}}','file-upload-reply-{{c.fullname}}')" hidden>
 				</label>
+				&nbsp;
+				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 			</div>
 			<a id="save-reply-to-{{c.fullname}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="post_comment('{{c.fullname}}', '{{c.post.id}}', {{level}})"role="button">Comment</a>
 			<a role="button" onclick="document.getElementById('reply-to-{{c.id}}').classList.add('d-none')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -275,11 +275,11 @@
 										<a class="format btn btn-secondary" role="button" onclick="makeItalics('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize"><i class="fas fa-italic" aria-hidden="true"></i></a> 
 										<a class="format btn btn-secondary" role="button" onclick="makeQuote('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote"><i class="fas fa-quote-right" aria-hidden="true"></i></a>
 										<a class="format btn btn-secondary" role="button" onclick="commentForm('post-edit-box-{{p.id}}');getGif()" aria-hidden="true" data-bs-toggle="modal" data-bs-target="#gifModal" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Add GIF"><span class="font-weight-bolder text-uppercase">GIF</span></a>
-										<label class="format btn btn-secondary m-0 ml-1 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-edit-{{p.id}}">
+										<a class="format btn btn-secondary" role="button" onclick="makeLink('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link" aria-hidden="true"></i></a>
+										<label class="format btn btn-secondary m-0 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-edit-{{p.id}}">
 											<div id="filename-show-edit-{{p.id}}"><i class="far fa-image"></i></div>
 											<input autocomplete="off" id="file-upload-edit-{{p.id}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-edit-{{p.id}}','file-upload-edit-{{p.id}}')" hidden>
 										</label>
-										<a class="format btn btn-secondary" role="button" onclick="makeLink('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link" aria-hidden="true"></i></a>
 									</div>
 								</div>
 								<button form="post-edit-form-{{p.id}}" class="btn btn-primary ml-2 fl-r">Save Edit</button>
@@ -423,17 +423,13 @@
 
 				<div class="comment-format">
 					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeBold('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Bold"><i class="fas fa-bold"></i></a>
-					&nbsp;
 					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeItalics('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Italicize"><i class="fas fa-italic"></i></a>
-					&nbsp;
 					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeQuote('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Quote"><i class="fas fa-quote-right"></i></a>
-					&nbsp;
-					<label class="format btn btn-secondary m-0 ml-1 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-reply-{{p.fullname}}">
+					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeLink('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
+					<label class="format btn btn-secondary m-0 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-reply-{{p.fullname}}">
 						<div id="filename-show-reply-{{p.fullname}}"><i class="far fa-image"></i></div>
 						<input autocomplete="off" id="file-upload-reply-{{p.fullname}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-reply-{{p.fullname}}','file-upload-reply-{{p.fullname}}')" hidden>
 					</label>
-					&nbsp;
-					<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 				</div>
 				<a id="save-reply-to-{{p.fullname}}" role="button" form="reply-to-{{p.fullname}}" class="btn btn-primary text-whitebtn ml-auto fl-r" onclick="post_comment('{{p.fullname}}', '{{p.id}}')">Comment</a>
 			</form>

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -279,8 +279,7 @@
 											<div id="filename-show-edit-{{p.id}}"><i class="far fa-image"></i></div>
 											<input autocomplete="off" id="file-upload-edit-{{p.id}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-edit-{{p.id}}','file-upload-edit-{{p.id}}')" hidden>
 										</label>
-						
-										<small class="format d-none"><i class="fas fa-link" aria-hidden="true"></i></small> 
+										<a class="format btn btn-secondary" role="button" onclick="makeLink('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link" aria-hidden="true"></i></a>
 									</div>
 								</div>
 								<button form="post-edit-form-{{p.id}}" class="btn btn-primary ml-2 fl-r">Save Edit</button>
@@ -433,6 +432,8 @@
 						<div id="filename-show-reply-{{p.fullname}}"><i class="far fa-image"></i></div>
 						<input autocomplete="off" id="file-upload-reply-{{p.fullname}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-reply-{{p.fullname}}','file-upload-reply-{{p.fullname}}')" hidden>
 					</label>
+					&nbsp;
+					<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
 				</div>
 				<a id="save-reply-to-{{p.fullname}}" role="button" form="reply-to-{{p.fullname}}" class="btn btn-primary text-whitebtn ml-auto fl-r" onclick="post_comment('{{p.fullname}}', '{{p.id}}')">Comment</a>
 			</form>

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -79,20 +79,19 @@
 												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeBold('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold">
 												<i class="fas fa-bold" aria-hidden="true"></i>
 												</small>
-												&nbsp; 
 												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeItalics('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize">
 												<i class="fas fa-italic" aria-hidden="true"></i>
 												</small>
-												&nbsp; 
 												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeQuote('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote">
 												<i class="fas fa-quote-right" aria-hidden="true"></i>
 												</small>
-												&nbsp;
-			
-												<label class="format btn btn-secondary m-0 ml-1 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-submit">
+												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeLink('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link">
+													<i class="fas fa-link" aria-hidden="true"></i>
+												</small>
+												<label class="format btn btn-secondary m-0 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-submit">
 													<div id="filename-show-submit"><i class="far fa-image"></i></div>
 													<input autocomplete="off" id="file-upload-submit" multiple="multiple" type="file" name="file2" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-submit','file-upload-submit');checkForRequired()" hidden>
-												</label>		
+												</label>	
 
 												<div id="preview" class="preview my-3"></div>
 


### PR DESCRIPTION
## Description

This PR is not associated with any pre-existing issue in the Issues list.

* Adds a button for adding links to all the textareas (create/edit post, create/edit comment, etc.)
* Adjust styles of the comment formatting buttons - no more positioning with `&nbsp;`!
* Modernizes the code handling formatting buttons - arrow functions and `let`/`const` wherever possible.

## Test plan

This is a purely frontend change, no proper frontend tests exist at the time.
- [x] all 569 existing tests pass