### PR TITLE
Refactor/remove editor redundancy

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -559,6 +559,7 @@ textarea.form-control {
 	font-size: 1rem;
 	line-height: 1.5;
 	border-radius: 0.35rem;
+	white-space: nowrap;
 	transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -3750,14 +3751,12 @@ ul.comment-section {
 	min-height: 84px;
 }
 .comment-format {
-	display: flex;
+	display: inline-flex;
 	gap: 4px;
 	align-items: center;
 	bottom: 0;
 	left: 0;
 	padding: 0.5rem 0 0 0;
-	width: 100%;
-	z-index: 1;
 }
 .comment-write .comment-format .format {
 	font-size: 1rem;

--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -59,25 +59,30 @@ function report_commentModal(id, author) {
 	}
 };
 
-function openReplyBox(id) {
+const openReplyBox = (id) => {
 	const element = document.getElementById(id);
-	const textarea = element.getElementsByTagName('textarea')[0]
-	let text = getSelection().toString()
+	const textarea = element.getElementsByTagName('textarea')[0];
+	const text = getSelection().toString();
 	if (text)
 	{
 		textarea.value = '>' + text
 		textarea.value = textarea.value.replace(/\n\n([^$])/g,"\n\n>$1")
-		if (!textarea.value.endsWith('\n\n')) textarea.value += '\n\n'
+		if (!textarea.value.endsWith('\n\n')) textarea.value += '\n\n';
+		markdown(textarea);
 	}
+	charLimit(textarea);
 	element.classList.remove('d-none')
-	textarea.focus()
+	textarea.focus();
 }
 
-function toggleEdit(id){
-	comment=document.getElementById("comment-text-"+id);
-	form=document.getElementById("comment-edit-"+id);
-	box=document.getElementById('comment-edit-body-'+id);
-	actions = document.getElementById('comment-' + id +'-actions');
+const toggleEdit = (id) =>{
+	const comment = document.getElementById(`comment-text-${id}`);
+	const form = document.getElementById(`comment-edit-${id}`);
+	const box = document.getElementById(`comment-edit-body-${id}`);
+	const actions = document.getElementById(`comment-${id}-actions`);
+
+	// Init preview and char count
+	box.oninput();
 
 	comment.classList.toggle("d-none");
 	form.classList.toggle("d-none");

--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -289,28 +289,22 @@ document.onpaste = function(event) {
 	];
 
 	const files = event.clipboardData.files;
-	if (!files.length) {
-		return;
-	}
+	if (files.length && relevantBodyIds.some((bodyId) => focused.id.includes(bodyId))) {
+		const idForFileInput = focused.dataset.idForFileInput;
+		const fileInput = document.getElementById(`file-reply-${idForFileInput}`);
+		const filenameContainer = document.getElementById(`filename-reply-${idForFileInput}`);
 
-	for (const bodyId of relevantBodyIds) {
-		if (focused.id.includes(bodyId)) {
-			const idForFileInput = focused.dataset.idForFileInput;
-			const fileInput = document.getElementById(`file-reply-${idForFileInput}`);
-			const filenameContainer = document.getElementById(`filename-reply-${idForFileInput}`);
-
-			try {
-				const filename = files[0].name.toLowerCase();
-				const allowedExtensions = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
-				if (allowedExtensions.some(extension => filename.endsWith(extension)))
-				{
-					fileInput.files = files;
-					filenameContainer.textContent = filename;
-				}
-				return;
+		try {
+			const filename = files[0].name.toLowerCase();
+			const allowedExtensions = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
+			if (allowedExtensions.some(extension => filename.endsWith(extension)))
+			{
+				fileInput.files = files;
+				filenameContainer.textContent = filename;
 			}
-			catch(e) {console.log(e)}
+			return;
 		}
+		catch(e) {console.log(e)}
 	}
 }
 

--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -276,41 +276,30 @@ function post_comment(fullname,id,level = 1){
 }
 
 document.onpaste = function(event) {
-	var focused = document.activeElement;
-	if (focused.id.includes('reply-form-body-')) {
-		var fullname = focused.dataset.fullname;
-		f=document.getElementById('file-upload-reply-' + fullname);
-		files = event.clipboardData.files
-		try {
-			filename = files[0].name.toLowerCase()
-			if (filename.endsWith(".jpg") || filename.endsWith(".jpeg") || filename.endsWith(".png") || filename.endsWith(".webp") || filename.endsWith(".gif"))
-			{
-				f.files = files;
-				document.getElementById('filename-show-reply-' + fullname).textContent = filename;
+	const focused = document.activeElement;
+	const relevantBodyIds = [
+		'reply-form-body-',
+		'comment-edit-body-',
+		'post-edit-box-'
+	];
+
+	for (const bodyId of relevantBodyIds) {
+		if (focused.id.includes(bodyId)) {
+			const idForFileInput = focused.dataset.idForFileInput;
+			const fileInput = document.getElementById(`file-reply-${idForFileInput}`);
+			const filenameContainer = document.getElementById(`filename-reply-${idForFileInput}`);
+			files = event.clipboardData.files
+			try {
+				filename = files[0].name.toLowerCase()
+				const allowedExtensions = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
+				if (allowedExtensions.some(extension => filename.endsWith(extension)))
+				{
+					fileInput.files = files;
+					filenameContainer.textContent = filename;
+				}
+				return;
 			}
-		}
-		catch(e) {console.log(e)}
-	}
-	else if (focused.id.includes('comment-edit-body-')) {
-		var id = focused.dataset.id;
-		f=document.getElementById('file-edit-reply-' + id);
-		files = event.clipboardData.files
-		filename = files[0].name.toLowerCase()
-		if (filename.endsWith(".jpg") || filename.endsWith(".jpeg") || filename.endsWith(".png") || filename.endsWith(".webp") || filename.endsWith(".gif"))
-		{
-			f.files = files;
-			document.getElementById('filename-edit-reply-' + id).textContent = filename;
-		}
-	}
-	else if (focused.id.includes('post-edit-box-')) {
-		var id = focused.dataset.id;
-		f=document.getElementById('file-upload-edit-' + id);
-		files = event.clipboardData.files
-		filename = files[0].name.toLowerCase()
-		if (filename.endsWith(".jpg") || filename.endsWith(".jpeg") || filename.endsWith(".png") || filename.endsWith(".webp") || filename.endsWith(".gif"))
-		{
-			f.files = files;
-			document.getElementById('filename-show-edit-' + id).textContent = filename;
+			catch(e) {console.log(e)}
 		}
 	}
 }

--- a/files/assets/js/comments_v.js
+++ b/files/assets/js/comments_v.js
@@ -283,14 +283,19 @@ document.onpaste = function(event) {
 		'post-edit-box-'
 	];
 
+	const files = event.clipboardData.files;
+	if (!files.length) {
+		return;
+	}
+
 	for (const bodyId of relevantBodyIds) {
 		if (focused.id.includes(bodyId)) {
 			const idForFileInput = focused.dataset.idForFileInput;
 			const fileInput = document.getElementById(`file-reply-${idForFileInput}`);
 			const filenameContainer = document.getElementById(`filename-reply-${idForFileInput}`);
-			files = event.clipboardData.files
+
 			try {
-				filename = files[0].name.toLowerCase()
+				const filename = files[0].name.toLowerCase();
 				const allowedExtensions = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
 				if (allowedExtensions.some(extension => filename.endsWith(extension)))
 				{

--- a/files/assets/js/header.js
+++ b/files/assets/js/header.js
@@ -180,11 +180,8 @@ function escapeHTML(unsafe) {
 	return unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
 }
 
-function changename(s1,s2) {
-	let files = document.getElementById(s2).files;
-	let filename = '';
-	for (const e of files) {
-		filename += e.name.substr(0, 20) + ', ';
-	}
-	document.getElementById(s1).innerHTML = escapeHTML(filename.slice(0, -2));
+function changename(containerId, inputId) {
+	const files = document.getElementById(inputId).files;
+	const filename = files.map(file => file.name.substr(0, 20)).join(', ');
+	document.getElementById(containerId).innerHTML = escapeHTML(filename);
 }

--- a/files/assets/js/marked.custom.js
+++ b/files/assets/js/marked.custom.js
@@ -68,20 +68,20 @@ function markdown(input) {
 	}
 }
 
-function charLimit(form, content) {
-	let input = document.getElementById(form);
-	let text = document.getElementById(content);
-	let length = input.value.length;
-	let maxLength = input.getAttribute("maxlength");
-
-	if (length >= maxLength) {
-		text.style.color = "#E53E3E";
+function charLimit(input) {
+	const display = input.parentElement.querySelector('.charcount');
+	if (display) {
+		const length = input.value.length;
+		const maxLength = input.getAttribute("maxlength");
+		display.innerText = `${length} / ${maxLength}`;
+		if (length >= maxLength) {
+			display.style.color = "#E53E3E";
+		}
+		else if (length >= maxLength * .72) {
+			display.style.color = "#FFC107";
+		}
+		else {
+			display.style.color = "#A0AEC0";
+		}
 	}
-	else if (length >= maxLength * .72){
-		text.style.color = "#FFC107";
-	}
-	else {
-		text.style.color = "#A0AEC0";
-	}
-	text.innerText = length + ' / ' + maxLength;
 }

--- a/files/assets/js/marked.custom.js
+++ b/files/assets/js/marked.custom.js
@@ -57,13 +57,10 @@ marked.use({
 	]
 });
 
-function markdown(first, second) {
-	var input = document.getElementById(first);
-	var dest = document.getElementById(second);
-	if(dest && input){
-		for (var i = 0; i < dest.children.length; i++) {
-			dest.removeChild(dest.children[i]);
-		}
+function markdown(input) {
+	const dest = input.parentElement.parentElement.querySelector('.preview');
+	if (dest) {
+		dest.innerHTML = '';
 		const html = marked.parse(input.value);
 		// https://github.com/themotte/rDrama/issues/139
 		// Remove disallowed tags completely.
@@ -88,5 +85,3 @@ function charLimit(form, content) {
 	}
 	text.innerText = length + ' / ' + maxLength;
 }
-
-setTimeout(() => markdown('post-text','preview'), 200);

--- a/files/assets/js/submit.js
+++ b/files/assets/js/submit.js
@@ -46,12 +46,11 @@ function hide_image() {
 }
 
 document.onpaste = function(event) {
-	files = event.clipboardData.files
+	const files = event.clipboardData.files
 
-	filename = files[0]
+	const filename = files[0]
 
-	if (filename)
-	{
+	if (filename) {
 		filename = filename.name.toLowerCase()
 		if (filename.endsWith(".jpg") || filename.endsWith(".jpeg") || filename.endsWith(".png") || filename.endsWith(".webp") || filename.endsWith(".gif"))
 		{

--- a/files/assets/js/submit.js
+++ b/files/assets/js/submit.js
@@ -1,6 +1,14 @@
-document.getElementById('post-title').value = localStorage.getItem("post_title")
-document.getElementById('post-text').value = localStorage.getItem("post_text")
-document.getElementById('post-url').value = localStorage.getItem("post_url")
+document.addEventListener('DOMContentLoaded', () => {
+	const postText = localStorage.getItem("post_text");
+	if (postText) {
+		const textArea = document.getElementById('post-text');
+		textArea.value = postText;
+		textArea.dispatchEvent(new Event('input'));
+	}
+	document.getElementById('post-title').value = localStorage.getItem("post_title");
+	document.getElementById('post-url').value = localStorage.getItem("post_url");
+	checkForRequired();
+});
 
 function checkForRequired() {
 	const title = document.getElementById("post-title");
@@ -8,7 +16,7 @@ function checkForRequired() {
 	const text = document.getElementById("post-text");
 	const button = document.getElementById("create_button");
 	const image = document.getElementById("file-upload");
-	const image2 = document.getElementById("file-upload-submit");
+	const image2 = document.getElementById("file-reply-submit");
 
 	if (url.value.length > 0 || image.files.length > 0 || image2.files.length > 0) {
 		text.required = false;
@@ -32,7 +40,6 @@ function checkForRequired() {
 		button.disabled = true;
 	}
 }
-checkForRequired();
 
 function hide_image() {
 	x=document.getElementById('image-upload-block');
@@ -45,28 +52,29 @@ function hide_image() {
 	}
 }
 
-document.onpaste = function(event) {
-	const files = event.clipboardData.files
+const IMAGE_FORMATS = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
 
-	const filename = files[0]
+document.onpaste = (event) => {
+	const files = event.clipboardData.files;
 
-	if (filename) {
-		filename = filename.name.toLowerCase()
-		if (filename.endsWith(".jpg") || filename.endsWith(".jpeg") || filename.endsWith(".png") || filename.endsWith(".webp") || filename.endsWith(".gif"))
-		{
+	if (files.length) {
+		const filename = files[0].name.toLowerCase();
+		if (IMAGE_FORMATS.some(extension => filename.endsWith(extension))) {
 			if (document.activeElement.id == 'post-text') {
-				document.getElementById('file-upload-submit').files = files;
-				document.getElementById('filename-show-submit').textContent = filename;
+				document.getElementById('file-reply-submit').files = files;
+				document.getElementById('filename-reply-submit').textContent = filename;
 			}
 			else {
-				f=document.getElementById('file-upload');
-				f.files = files;
+				const fileInput = document.getElementById('file-upload');
+				fileInput.files = files;
 				document.getElementById('filename-show').textContent = filename;
 				document.getElementById('urlblock').classList.add('d-none');
-				var fileReader = new FileReader();
-				fileReader.readAsDataURL(f.files[0]);
-				fileReader.addEventListener("load", function () {document.getElementById('image-preview').setAttribute('src', this.result);});  
-				document.getElementById('file-upload').setAttribute('required', 'false');	
+				const fileReader = new FileReader();
+				fileReader.readAsDataURL(fileInput.files[0]);
+				fileReader.addEventListener("load", function () {
+					document.getElementById('image-preview').setAttribute('src', this.result);
+				});  
+				fileInput.setAttribute('required', 'false');	
 			}
 			document.getElementById('post-url').value = null;
 			localStorage.setItem("post_url", "")
@@ -76,15 +84,14 @@ document.onpaste = function(event) {
 }
 
 document.getElementById('file-upload').addEventListener('change', function(){
-	f=document.getElementById('file-upload');
+	const fileInput = document.getElementById('file-upload');
 	document.getElementById('urlblock').classList.add('d-none');
-	document.getElementById('filename-show').textContent = document.getElementById('file-upload').files[0].name.substr(0, 20);
-	filename = f.files[0].name.toLowerCase()
-	if (filename.endsWith(".jpg") || filename.endsWith(".jpeg") || filename.endsWith(".png") || filename.endsWith(".webp") || filename.endsWith(".webp"))
-	{
-		var fileReader = new FileReader();
-		fileReader.readAsDataURL(f.files[0]);
-		fileReader.addEventListener("load", function () {document.getElementById('image-preview').setAttribute('src', this.result);});  
+	document.getElementById('filename-show').textContent = fileInput.files[0].name.substr(0, 20);
+	const filename = fileInput.files[0].name.toLowerCase();
+	if (IMAGE_FORMATS.some(extension => filename.endsWith(extension))) {
+		const fileReader = new FileReader();
+		fileReader.readAsDataURL(fileInput.files[0]);
+		fileReader.addEventListener("load", () => document.getElementById('image-preview').setAttribute('src', this.result));  
 	}
 	checkForRequired();
 })

--- a/files/assets/js/togglePostEdit.js
+++ b/files/assets/js/togglePostEdit.js
@@ -1,8 +1,11 @@
-function togglePostEdit(id){
-	body=document.getElementById("post-body");
-	title=document.getElementById("post-title");
-	form=document.getElementById("edit-post-body-"+id);
-	box=document.getElementById("post-edit-box-"+id);
+const togglePostEdit = (id) =>	{
+	const body = document.getElementById("post-body");
+	const title = document.getElementById("post-title");
+	const form = document.getElementById(`edit-post-body-${id}`);
+	const box = document.getElementById(`post-edit-box-${id}`);
+
+	// Init preview and char count
+	box.oninput();
 
 	body.classList.toggle("d-none");
 	title.classList.toggle("d-none");

--- a/files/templates/component/comment/_editor_buttons.html
+++ b/files/templates/component/comment/_editor_buttons.html
@@ -1,0 +1,22 @@
+{% macro editor_buttons(id, body_id) %}
+<div class="comment-format">
+    <a class="btn btn-secondary format m-0" role="button" onclick="makeBold('{{ body_id }}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold"><i class="fas fa-bold"></i></a>
+    <a class="btn btn-secondary format m-0" role="button" onclick="makeItalics('{{ body_id }}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize"><i class="fas fa-italic"></i></a>
+    <a class="btn btn-secondary format m-0" role="button" onclick="makeQuote('{{ body_id }}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote"><i class="fas fa-quote-right"></i></a>
+    <a class="btn btn-secondary format m-0" role="button" onclick="makeLink('{{ body_id }}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
+    <label class="btn btn-secondary format m-0" for="file-reply-{{ id }}">
+        <div id="filename-reply-{{ id }}"><i class="far fa-image"></i></div>
+            <input
+                autocomplete="off"
+                id="file-reply-{{ id }}"
+                type="file"
+                multiple="multiple"
+                name="file"
+                accept="image\/*, video\/*"
+                {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %}
+                onchange="changename('filename-reply-{{ id }}','file-reply-{{ id }}')"
+                hidden
+            >
+    </label>
+</div>
+{% endmacro %}

--- a/files/templates/component/comment/editbox_comment.html
+++ b/files/templates/component/comment/editbox_comment.html
@@ -2,8 +2,8 @@
 	<div id="comment-edit-{{c.id}}" class="d-none comment-write collapsed child">
 		<form id="comment-edit-form-{{c.id}}" action="/edit_comment/{{c.id}}" method="post" enctype="multipart/form-data"> 
 			<input type="hidden" name="formkey" value="{{v.formkey}}">
-			<textarea autocomplete="off" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('comment-edit-body-{{c.id}}','charcount-edit-{{c.id}}')" id="comment-edit-body-{{c.id}}" data-id-for-file-input="comment-{{c.id}}" name="body" form="comment-edit-form-{{c.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{c.body}}</textarea> 
-			<div class="text-small font-weight-bold mt-1" id="charcount-edit-{{c.id}}" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+			<textarea autocomplete="off" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit(this)" id="comment-edit-body-{{c.id}}" data-id-for-file-input="comment-{{c.id}}" name="body" form="comment-edit-form-{{c.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{c.body}}</textarea> 
+			<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 			
 			{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
 			{{ editor_buttons('comment-' ~ c.id, 'comment-edit-body-' ~ c.id) }}

--- a/files/templates/component/comment/editbox_comment.html
+++ b/files/templates/component/comment/editbox_comment.html
@@ -2,7 +2,7 @@
 	<div id="comment-edit-{{c.id}}" class="d-none comment-write collapsed child">
 		<form id="comment-edit-form-{{c.id}}" action="/edit_comment/{{c.id}}" method="post" enctype="multipart/form-data"> 
 			<input type="hidden" name="formkey" value="{{v.formkey}}">
-			<textarea autocomplete="off" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('comment-edit-body-{{c.id}}', 'preview-edit-{{c.id}}');charLimit('comment-edit-body-{{c.id}}','charcount-edit-{{c.id}}')" id="comment-edit-body-{{c.id}}" data-id-for-file-input="comment-{{c.id}}" name="body" form="comment-edit-form-{{c.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{c.body}}</textarea> 
+			<textarea autocomplete="off" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('comment-edit-body-{{c.id}}','charcount-edit-{{c.id}}')" id="comment-edit-body-{{c.id}}" data-id-for-file-input="comment-{{c.id}}" name="body" form="comment-edit-form-{{c.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{c.body}}</textarea> 
 			<div class="text-small font-weight-bold mt-1" id="charcount-edit-{{c.id}}" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 			
 			{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
@@ -11,7 +11,7 @@
 			<a id="edit-btn-{{c.id}}" role="button" form="comment-edit-form-{{c.id}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="comment_edit('{{c.id}}')">Save Edit</a> 
 			<a id="cancel-edit-{{c.id}}" role="button" onclick="toggleEdit('{{c.id}}')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 
 		</form>
-		<div id="preview-edit-{{c.id}}" class="preview mb-3 mt-5"></div>
+		<div class="preview mb-3 mt-5"></div>
 		<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
 	</div>
 {% endif %}

--- a/files/templates/component/comment/editbox_comment.html
+++ b/files/templates/component/comment/editbox_comment.html
@@ -2,19 +2,12 @@
 	<div id="comment-edit-{{c.id}}" class="d-none comment-write collapsed child">
 		<form id="comment-edit-form-{{c.id}}" action="/edit_comment/{{c.id}}" method="post" enctype="multipart/form-data"> 
 			<input type="hidden" name="formkey" value="{{v.formkey}}">
-			<textarea autocomplete="off" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('comment-edit-body-{{c.id}}', 'preview-edit-{{c.id}}');charLimit('comment-edit-body-{{c.id}}','charcount-edit-{{c.id}}')" id="comment-edit-body-{{c.id}}" data-id="{{c.id}}" name="body" form="comment-edit-form-{{c.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{c.body}}</textarea> 
+			<textarea autocomplete="off" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('comment-edit-body-{{c.id}}', 'preview-edit-{{c.id}}');charLimit('comment-edit-body-{{c.id}}','charcount-edit-{{c.id}}')" id="comment-edit-body-{{c.id}}" data-id-for-file-input="comment-{{c.id}}" name="body" form="comment-edit-form-{{c.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3">{{c.body}}</textarea> 
 			<div class="text-small font-weight-bold mt-1" id="charcount-edit-{{c.id}}" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
-			<div class="comment-format">
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeBold('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold"><i class="fas fa-bold"></i></a>
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeItalics('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize"><i class="fas fa-italic"></i></a>
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeQuote('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote"><i class="fas fa-quote-right"></i></a>
-				<small class="btn btn-secondary format m-0" aria-hidden="true" onclick="commentForm('comment-edit-body-{{c.id}}');getGif()" data-bs-toggle="modal" data-bs-target="#gifModal" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Add GIF"><span class="font-weight-bolder text-uppercase">GIF</span></small>
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('comment-edit-body-{{c.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
-				<label class="btn btn-secondary format m-0" for="file-edit-reply-{{c.id}}">
-					<div id="filename-edit-reply-{{c.id}}"><i class="far fa-image"></i></div>
-						<input autocomplete="off" id="file-edit-reply-{{c.id}}" type="file" multiple="multiple" name="file" accept="image\/*, video\/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-edit-reply-{{c.id}}','file-edit-reply-{{c.id}}')" hidden>
-				</label>
-			</div>
+			
+			{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
+			{{ editor_buttons('comment-' ~ c.id, 'comment-edit-body-' ~ c.id) }}
+
 			<a id="edit-btn-{{c.id}}" role="button" form="comment-edit-form-{{c.id}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="comment_edit('{{c.id}}')">Save Edit</a> 
 			<a id="cancel-edit-{{c.id}}" role="button" onclick="toggleEdit('{{c.id}}')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 
 		</form>

--- a/files/templates/component/comment/replybox_comment.html
+++ b/files/templates/component/comment/replybox_comment.html
@@ -4,20 +4,13 @@
 			<input type="hidden" name="formkey" value="{{v.formkey}}"> 
 			<input type="hidden" name="parent_fullname" value="{{c.fullname}}"> 
 			<input autocomplete="off" id="reply-form-submission-{{c.fullname}}" type="hidden" name="submission" value="{{c.post.id}}"> 
-			<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('reply-form-body-{{c.fullname}}', 'reply-edit-{{c.id}}');charLimit('reply-form-body-{{c.fullname}}','charcount-{{c.id}}')" id="reply-form-body-{{c.fullname}}" data-fullname="{{c.fullname}}" name="body" form="reply-to-{{c.fullname}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
+			<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('reply-form-body-{{c.fullname}}', 'reply-edit-{{c.id}}');charLimit('reply-form-body-{{c.fullname}}','charcount-{{c.id}}')" id="reply-form-body-{{c.fullname}}" data-id-for-file-input="comment-{{c.fullname}}" name="body" form="reply-to-{{c.fullname}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
 	
 			<div class="text-small font-weight-bold mt-1" id="charcount-{{c.id}}" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
-			<div class="comment-format" id="comment-format-bar-{{c.id}}"> 
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeBold('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold"><i class="fas fa-bold"></i></a>
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeItalics('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize"><i class="fas fa-italic"></i></a>
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeQuote('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote"><i class="fas fa-quote-right"></i></a>
-				<a class="btn btn-secondary format m-0" role="button" onclick="makeLink('reply-form-body-{{c.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
-				<label class="btn btn-secondary format m-0" for="file-upload-reply-{{c.fullname}}">
-					<div id="filename-show-reply-{{c.fullname}}"><i class="far fa-image"></i></div>
-					<input autocomplete="off" id="file-upload-reply-{{c.fullname}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-reply-{{c.fullname}}','file-upload-reply-{{c.fullname}}')" hidden>
-				</label>
-			</div>
+			{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
+			{{ editor_buttons('comment-' ~ c.fullname, 'reply-form-body-' ~ c.fullname) }}
+
 			<a id="save-reply-to-{{c.fullname}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="post_comment('{{c.fullname}}', '{{c.post.id}}', {{level}})"role="button">Comment</a>
 			<a role="button" onclick="document.getElementById('reply-to-{{c.id}}').classList.add('d-none')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 
 		</form>

--- a/files/templates/component/comment/replybox_comment.html
+++ b/files/templates/component/comment/replybox_comment.html
@@ -4,9 +4,9 @@
 			<input type="hidden" name="formkey" value="{{v.formkey}}"> 
 			<input type="hidden" name="parent_fullname" value="{{c.fullname}}"> 
 			<input autocomplete="off" id="reply-form-submission-{{c.fullname}}" type="hidden" name="submission" value="{{c.post.id}}"> 
-			<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('reply-form-body-{{c.fullname}}','charcount-{{c.id}}')" id="reply-form-body-{{c.fullname}}" data-id-for-file-input="comment-{{c.fullname}}" name="body" form="reply-to-{{c.fullname}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
+			<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit(this)" id="reply-form-body-{{c.fullname}}" data-id-for-file-input="comment-{{c.fullname}}" name="body" form="reply-to-{{c.fullname}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
 	
-			<div class="text-small font-weight-bold mt-1" id="charcount-{{c.id}}" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+			<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
 			{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
 			{{ editor_buttons('comment-' ~ c.fullname, 'reply-form-body-' ~ c.fullname) }}

--- a/files/templates/component/comment/replybox_comment.html
+++ b/files/templates/component/comment/replybox_comment.html
@@ -4,7 +4,7 @@
 			<input type="hidden" name="formkey" value="{{v.formkey}}"> 
 			<input type="hidden" name="parent_fullname" value="{{c.fullname}}"> 
 			<input autocomplete="off" id="reply-form-submission-{{c.fullname}}" type="hidden" name="submission" value="{{c.post.id}}"> 
-			<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('reply-form-body-{{c.fullname}}', 'reply-edit-{{c.id}}');charLimit('reply-form-body-{{c.fullname}}','charcount-{{c.id}}')" id="reply-form-body-{{c.fullname}}" data-id-for-file-input="comment-{{c.fullname}}" name="body" form="reply-to-{{c.fullname}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
+			<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('reply-form-body-{{c.fullname}}','charcount-{{c.id}}')" id="reply-form-body-{{c.fullname}}" data-id-for-file-input="comment-{{c.fullname}}" name="body" form="reply-to-{{c.fullname}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
 	
 			<div class="text-small font-weight-bold mt-1" id="charcount-{{c.id}}" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
@@ -14,7 +14,7 @@
 			<a id="save-reply-to-{{c.fullname}}" class="btn btn-primary ml-2 fl-r commentmob" onclick="post_comment('{{c.fullname}}', '{{c.post.id}}', {{level}})"role="button">Comment</a>
 			<a role="button" onclick="document.getElementById('reply-to-{{c.id}}').classList.add('d-none')" class="btn btn-link text-muted ml-auto cancel-form fl-r commentmob">Cancel</a> 
 		</form>
-		<div id="reply-edit-{{c.id}}" class="preview mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>
+		<div class="preview mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>
 		<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
 	</div>
 </div>

--- a/files/templates/component/comment/replybox_message.html
+++ b/files/templates/component/comment/replybox_message.html
@@ -3,7 +3,7 @@
 	<div id="comment-form-space-{{c.id}}" class="comment-write collapsed child">		
 		<form id="reply-to-message-{{c.id}}" action="/reply" method="post" class="input-group" enctype="multipart/form-data">
 			<input type="hidden" name="formkey" value="{{v.formkey}}"> 
-			<textarea required autocomplete="off" minlength="1" maxlength="{{MESSAGE_BODY_LENGTH_MAXIMUM}}" name="body" form="reply-to-message-{{c.id}}" data-id="{{c.id}}" class="comment-box form-control rounded" id="reply-form-body-{{c.id}}" aria-label="With textarea" rows="3" oninput="markdown('reply-form-body-{{c.id}}', 'message-reply-{{c.id}}')"></textarea>
+			<textarea required autocomplete="off" minlength="1" maxlength="{{MESSAGE_BODY_LENGTH_MAXIMUM}}" name="body" form="reply-to-message-{{c.id}}" data-id="{{c.id}}" class="comment-box form-control rounded" id="reply-form-body-{{c.id}}" aria-label="With textarea" rows="3" oninput="markdown(this)"></textarea>
 			<div class="comment-format" id="comment-format-bar-{{c.id}}">
 				{% if c.sentto == MODMAIL_ID %}
 					<label class="btn btn-secondary m-0 mt-3" for="file-upload">
@@ -15,6 +15,6 @@
 			<a role="button" onclick="document.getElementById('reply-message-{{c.id}}').classList.add('d-none')" class="btn btn-link text-muted ml-auto cancel-form">Cancel</a> 
 			<a id="save-reply-to-{{c.id}}" class="btn btn-primary ml-2" onclick="post_reply('{{c.id}}') "role="button">Reply</a> 
 		</form>
-		<div id="message-reply-{{c.id}}" class="preview mt-2"></div>
+		<div class="preview mt-2"></div>
 	</div>
 </div>

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -266,21 +266,12 @@
 									{{forms.formkey(v)}}
 									<input type="hidden" name="current_page" value="{{request.path}}">
 									<input type="text" autocomplete="off" maxlength="{{SUBMISSION_TITLE_LENGTH_MAXIMUM}}" name="title" class="comment-box form-control rounded" required placeholder="title" value="{{p.title}}"\>
-									<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown('post-edit-box-{{p.id}}', 'post-edit-{{p.id}}');charLimit('post-edit-box-{{p.id}}','charcount-post-edit')" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id="{{p.id}}">{{p.body}}</textarea> 
+									<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown('post-edit-box-{{p.id}}', 'post-edit-{{p.id}}');charLimit('post-edit-box-{{p.id}}','charcount-post-edit')" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id-for-file-input="post-{{p.id}}">{{p.body}}</textarea> 
 									
 									<div class="text-small font-weight-bold mt-1" id="charcount-post-edit" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
-									<div class="comment-format">
-										<small class="format btn btn-secondary"><i class="fas fa-bold" aria-hidden="true" onclick="makeBold('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold"></i></small> 
-										<a class="format btn btn-secondary" role="button" onclick="makeItalics('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize"><i class="fas fa-italic" aria-hidden="true"></i></a> 
-										<a class="format btn btn-secondary" role="button" onclick="makeQuote('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote"><i class="fas fa-quote-right" aria-hidden="true"></i></a>
-										<a class="format btn btn-secondary" role="button" onclick="commentForm('post-edit-box-{{p.id}}');getGif()" aria-hidden="true" data-bs-toggle="modal" data-bs-target="#gifModal" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Add GIF"><span class="font-weight-bolder text-uppercase">GIF</span></a>
-										<a class="format btn btn-secondary" role="button" onclick="makeLink('post-edit-box-{{p.id}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link" aria-hidden="true"></i></a>
-										<label class="format btn btn-secondary m-0 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-edit-{{p.id}}">
-											<div id="filename-show-edit-{{p.id}}"><i class="far fa-image"></i></div>
-											<input autocomplete="off" id="file-upload-edit-{{p.id}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-edit-{{p.id}}','file-upload-edit-{{p.id}}')" hidden>
-										</label>
-									</div>
+									{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
+									{{ editor_buttons('post-' ~ p.id, 'post-edit-box-' ~ p.id) }}
 								</div>
 								<button form="post-edit-form-{{p.id}}" class="btn btn-primary ml-2 fl-r">Save Edit</button>
 								<a role="button" onclick="togglePostEdit('{{p.id}}')" class="btn btn-link text-muted ml-auto cancel-form fl-r">Cancel</a> 
@@ -417,20 +408,13 @@
 				{{forms.formkey(v)}}
 				<input type="hidden" name="parent_fullname" value="{{p.fullname}}">
 				<input autocomplete="off" id="reply-form-submission-{{p.fullname}}" type="hidden" name="submission" value="{{p.id}}">
-				<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('reply-form-body-{{p.fullname}}', 'form-preview-{{p.id}}');charLimit('reply-form-body-{{p.fullname}}','charcount-reply')" id="reply-form-body-{{p.fullname}}" data-fullname="{{p.fullname}}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{p.fullname}}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
+				<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('reply-form-body-{{p.fullname}}', 'form-preview-{{p.id}}');charLimit('reply-form-body-{{p.fullname}}','charcount-reply')" id="reply-form-body-{{p.fullname}}" data-id-for-file-input="post-{{p.fullname}}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{p.fullname}}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
 
 				<div class="text-small font-weight-bold mt-1" id="charcount-reply" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
-				<div class="comment-format">
-					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeBold('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Bold"><i class="fas fa-bold"></i></a>
-					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeItalics('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Italicize"><i class="fas fa-italic"></i></a>
-					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeQuote('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom"  title="Quote"><i class="fas fa-quote-right"></i></a>
-					<a class="btn btn-secondary format d-inline-block m-0" role="button" onclick="makeLink('reply-form-body-{{p.fullname}}')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link"><i class="fas fa-link"></i></a>
-					<label class="format btn btn-secondary m-0 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-reply-{{p.fullname}}">
-						<div id="filename-show-reply-{{p.fullname}}"><i class="far fa-image"></i></div>
-						<input autocomplete="off" id="file-upload-reply-{{p.fullname}}" type="file" multiple="multiple" name="file" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-reply-{{p.fullname}}','file-upload-reply-{{p.fullname}}')" hidden>
-					</label>
-				</div>
+				{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
+				{{ editor_buttons('post-' ~ p.fullname, 'reply-form-body-' ~ p.fullname) }}
+
 				<a id="save-reply-to-{{p.fullname}}" role="button" form="reply-to-{{p.fullname}}" class="btn btn-primary text-whitebtn ml-auto fl-r" onclick="post_comment('{{p.fullname}}', '{{p.id}}')">Comment</a>
 			</form>
 			<div id="form-preview-{{p.id}}" class="text-small mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -266,7 +266,7 @@
 									{{forms.formkey(v)}}
 									<input type="hidden" name="current_page" value="{{request.path}}">
 									<input type="text" autocomplete="off" maxlength="{{SUBMISSION_TITLE_LENGTH_MAXIMUM}}" name="title" class="comment-box form-control rounded" required placeholder="title" value="{{p.title}}"\>
-									<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown('post-edit-box-{{p.id}}', 'post-edit-{{p.id}}');charLimit('post-edit-box-{{p.id}}','charcount-post-edit')" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id-for-file-input="post-{{p.id}}">{{p.body}}</textarea> 
+									<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('post-edit-box-{{p.id}}','charcount-post-edit')" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id-for-file-input="post-{{p.id}}">{{p.body}}</textarea> 
 									
 									<div class="text-small font-weight-bold mt-1" id="charcount-post-edit" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
@@ -276,7 +276,7 @@
 								<button form="post-edit-form-{{p.id}}" class="btn btn-primary ml-2 fl-r">Save Edit</button>
 								<a role="button" onclick="togglePostEdit('{{p.id}}')" class="btn btn-link text-muted ml-auto cancel-form fl-r">Cancel</a> 
 							</form>
-							<div id="post-edit-{{p.id}}" class="preview mb-3 mt-5"></div>
+							<div class="preview mb-3 mt-5"></div>
 							<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
 						</div>
 					{% endif %}
@@ -408,7 +408,7 @@
 				{{forms.formkey(v)}}
 				<input type="hidden" name="parent_fullname" value="{{p.fullname}}">
 				<input autocomplete="off" id="reply-form-submission-{{p.fullname}}" type="hidden" name="submission" value="{{p.id}}">
-				<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown('reply-form-body-{{p.fullname}}', 'form-preview-{{p.id}}');charLimit('reply-form-body-{{p.fullname}}','charcount-reply')" id="reply-form-body-{{p.fullname}}" data-id-for-file-input="post-{{p.fullname}}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{p.fullname}}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
+				<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('reply-form-body-{{p.fullname}}','charcount-reply')" id="reply-form-body-{{p.fullname}}" data-id-for-file-input="post-{{p.fullname}}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{p.fullname}}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
 
 				<div class="text-small font-weight-bold mt-1" id="charcount-reply" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
@@ -417,7 +417,7 @@
 
 				<a id="save-reply-to-{{p.fullname}}" role="button" form="reply-to-{{p.fullname}}" class="btn btn-primary text-whitebtn ml-auto fl-r" onclick="post_comment('{{p.fullname}}', '{{p.id}}')">Comment</a>
 			</form>
-			<div id="form-preview-{{p.id}}" class="text-small mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>
+			<div class="preview text-small mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>
 			<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
 		</div>
 	{% else %}

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -261,20 +261,21 @@
 
 					{% if v and v.can_edit(p) %}
 						<div id="edit-post-body-{{p.id}}" class="d-none comment-write collapsed child">
-							<form id="post-edit-form-{{p.id}}" action="{{p.edit_url}}" method="post" enctype="multipart/form-data">
-								<div class="d-flex flex-column">
-									{{forms.formkey(v)}}
-									<input type="hidden" name="current_page" value="{{request.path}}">
-									<input type="text" autocomplete="off" maxlength="{{SUBMISSION_TITLE_LENGTH_MAXIMUM}}" name="title" class="comment-box form-control rounded" required placeholder="title" value="{{p.title}}"\>
-									<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit(this)" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id-for-file-input="post-{{p.id}}">{{p.body}}</textarea> 
-									
-									<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+							<form class="d-flex flex-column" id="post-edit-form-{{p.id}}" action="{{p.edit_url}}" method="post" enctype="multipart/form-data">
+								{{forms.formkey(v)}}
+								<input type="hidden" name="current_page" value="{{request.path}}">
+								<input type="text" autocomplete="off" maxlength="{{SUBMISSION_TITLE_LENGTH_MAXIMUM}}" name="title" class="comment-box form-control rounded" required placeholder="title" value="{{p.title}}"\>
+								<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit(this)" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id-for-file-input="post-{{p.id}}">{{p.body}}</textarea> 
+								
+								<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
+								<div class="d-flex justify-content-between">
 									{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
 									{{ editor_buttons('post-' ~ p.id, 'post-edit-box-' ~ p.id) }}
+
+									<a role="button" onclick="togglePostEdit('{{p.id}}')" class="btn btn-link mt-2 text-muted ml-auto cancel-form">Cancel</a>
+									<button form="post-edit-form-{{p.id}}" class="btn btn-primary mt-2">Save Edit</button>
 								</div>
-								<button form="post-edit-form-{{p.id}}" class="btn btn-primary ml-2 fl-r">Save Edit</button>
-								<a role="button" onclick="togglePostEdit('{{p.id}}')" class="btn btn-link text-muted ml-auto cancel-form fl-r">Cancel</a> 
 							</form>
 							<div class="preview mb-3 mt-5"></div>
 							<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
@@ -410,12 +411,14 @@
 				<input autocomplete="off" id="reply-form-submission-{{p.fullname}}" type="hidden" name="submission" value="{{p.id}}">
 				<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit(this)" id="reply-form-body-{{p.fullname}}" data-id-for-file-input="post-{{p.fullname}}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{p.fullname}}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
 
-				<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+				<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3; color: #A0AEC0;">0 / {{COMMENT_BODY_LENGTH_MAXIMUM}}</div>
 
-				{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
-				{{ editor_buttons('post-' ~ p.fullname, 'reply-form-body-' ~ p.fullname) }}
+				<div class="d-flex justify-content-between">
+					{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
+					{{ editor_buttons('post-' ~ p.fullname, 'reply-form-body-' ~ p.fullname) }}
 
-				<a id="save-reply-to-{{p.fullname}}" role="button" form="reply-to-{{p.fullname}}" class="btn btn-primary text-whitebtn ml-auto fl-r" onclick="post_comment('{{p.fullname}}', '{{p.id}}')">Comment</a>
+					<a id="save-reply-to-{{p.fullname}}" role="button" form="reply-to-{{p.fullname}}" class="btn btn-primary mt-2" onclick="post_comment('{{p.fullname}}', '{{p.id}}')">Comment</a>
+				</div>
 			</form>
 			<div class="preview text-small mb-3 mt-5"><p class="preview-msg">Comment preview</p></div>
 			<div class="form-text text-small p-0 m-0"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -266,9 +266,9 @@
 									{{forms.formkey(v)}}
 									<input type="hidden" name="current_page" value="{{request.path}}">
 									<input type="text" autocomplete="off" maxlength="{{SUBMISSION_TITLE_LENGTH_MAXIMUM}}" name="title" class="comment-box form-control rounded" required placeholder="title" value="{{p.title}}"\>
-									<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('post-edit-box-{{p.id}}','charcount-post-edit')" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id-for-file-input="post-{{p.id}}">{{p.body}}</textarea> 
+									<textarea autocomplete="off" name="body" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit(this)" id="post-edit-box-{{p.id}}" form="post-edit-form-{{p.id}}" class="comment-box form-control rounded" aria-label="With textarea" placeholder="Add text to your post..." rows="10" data-id-for-file-input="post-{{p.id}}">{{p.body}}</textarea> 
 									
-									<div class="text-small font-weight-bold mt-1" id="charcount-post-edit" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+									<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
 									{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
 									{{ editor_buttons('post-' ~ p.id, 'post-edit-box-' ~ p.id) }}
@@ -408,9 +408,9 @@
 				{{forms.formkey(v)}}
 				<input type="hidden" name="parent_fullname" value="{{p.fullname}}">
 				<input autocomplete="off" id="reply-form-submission-{{p.fullname}}" type="hidden" name="submission" value="{{p.id}}">
-				<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit('reply-form-body-{{p.fullname}}','charcount-reply')" id="reply-form-body-{{p.fullname}}" data-id-for-file-input="post-{{p.fullname}}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{p.fullname}}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
+				<textarea required autocomplete="off" minlength="1" maxlength="{{COMMENT_BODY_LENGTH_MAXIMUM}}" oninput="markdown(this);charLimit(this)" id="reply-form-body-{{p.fullname}}" data-id-for-file-input="post-{{p.fullname}}" class="comment-box form-control rounded" id="comment-form" name="body" form="reply-to-{{p.fullname}}" aria-label="With textarea" placeholder="Add your comment..." rows="3"></textarea>
 
-				<div class="text-small font-weight-bold mt-1" id="charcount-reply" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+				<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
 				{% from 'component/comment/_editor_buttons.html' import editor_buttons %}
 				{{ editor_buttons('post-' ~ p.fullname, 'reply-form-body-' ~ p.fullname) }}

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -65,7 +65,7 @@
 												<label for="body" class="mt-3">Text<i class="fas fa-info-circle text-gray-400 ml-1" data-bs-toggle="tooltip" data-bs-placement="top" title="Uses markdown. Limited to {{SUBMISSION_BODY_LENGTH_MAXIMUM}} characters."></i></label>
 
 												<div>
-													<textarea form="submitform" id="post-text" class="form-control rounded" aria-label="With textarea" placeholder="Optional if you have a link or an image." rows="7" name="body" oninput="markdown('post-text','preview');charLimit('post-text','character-count-submit-text-form');checkForRequired();savetext()" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" required></textarea>
+													<textarea form="submitform" id="post-text" class="form-control rounded" aria-label="With textarea" placeholder="Optional if you have a link or an image." rows="7" name="body" oninput="markdown(this);charLimit('post-text','character-count-submit-text-form');checkForRequired();savetext()" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" required></textarea>
 
 													<div class="btn btn-secondary fl-r mt-3" onclick="document.getElementById('preview').classList.toggle('d-none');">
 														Toggle preview

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -28,121 +28,108 @@
 			<link rel="stylesheet" href="{{ ('css/'~config('DEFAULT_THEME')~'.css') | asset }}">
 		{% endif %}
 		{% endblock %}
+</head>
 
 <body id="submit">
-{% include "header.html" %}
-{% block form %}
+	{% include "header.html" %}
+	{% block form %}
 		<div class="submit-grid-view">
 			<form id="submitform" action="/submit" method="post" enctype="multipart/form-data" style="grid-column: 2">
 				<div class="container">
-						<div class="row justify-content-center mb-5">
-								<div class="col p-3 py-md-0">
-										<h2 class="mt-3">Create a post</h2>
-										<div class="body">
-												{{forms.formkey(v)}}
-												<label class='mt-4' for="title">Post Title</label>
+					<div class="row justify-content-center mb-5">
+						<div class="col p-3 py-md-0">
+							<h2 class="mt-3">Create a post</h2>
+							<div class="body">
+								{{forms.formkey(v)}}
+								<label class='mt-4' for="title">Post Title</label>
 
-												<input autocomplete="off" class="form-control" id="post-title" aria-describedby="titleHelpRegister" type="text" name="title" placeholder="Required" value="{{title}}" minlength="1" maxlength="{{SUBMISSION_TITLE_LENGTH_MAXIMUM}}" required oninput="checkForRequired();savetext()">
+								<input autocomplete="off" class="form-control" id="post-title" aria-describedby="titleHelpRegister" type="text" name="title" placeholder="Required" value="{{title}}" minlength="1" maxlength="{{SUBMISSION_TITLE_LENGTH_MAXIMUM}}" required oninput="checkForRequired();savetext()">
 
-												<div id="urlblock">
-														<label for="URL" class="mt-3">URL</label>
-														<input autocomplete="off" class="form-control" id="post-url" aria-describedby="URLHelp" name="url" type="url" placeholder="Optional if you have text." value="{{request.values.get('url','')}}" maxlength="2048" required oninput="checkForRequired();hide_image();savetext();checkRepost(this);autoSuggestTitle()">
-														<small id="system" class="form-text text-muted">To post an image, use a direct image link such as i.imgur.com</small>
-												</div>
-												<div id="image-upload-block">
-													<div><label class="mt-3">Attachment Upload</label></div>
-
-													<img loading="lazy" id="image-preview" style="max-width:50%">
-													<label class="btn btn-secondary m-0" for="file-upload">
-														<div id="filename-show">Select File</div>
-														<input autocomplete="off" id="file-upload" type="file" name="file" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} accept="image/*" hidden>
-													</label>
-													<small class="form-text text-muted">Optional if you have text.</small>
-													<small class="form-text text-muted">You can upload images or videos up to 60 seconds.</small>
-												</div>
-												</div>
-
-												<label for="body" class="mt-3">Text<i class="fas fa-info-circle text-gray-400 ml-1" data-bs-toggle="tooltip" data-bs-placement="top" title="Uses markdown. Limited to {{SUBMISSION_BODY_LENGTH_MAXIMUM}} characters."></i></label>
-
-												<div>
-													<textarea form="submitform" id="post-text" class="form-control rounded" aria-label="With textarea" placeholder="Optional if you have a link or an image." rows="7" name="body" oninput="markdown(this);charLimit(this);checkForRequired();savetext()" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" required></textarea>
-
-													<div class="btn btn-secondary fl-r mt-3" onclick="document.getElementById('preview').classList.toggle('d-none');">
-														Toggle preview
-													</div>
-
-													<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
-
-												</div>
-
-												<p></p>
-												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeBold('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Bold">
-												<i class="fas fa-bold" aria-hidden="true"></i>
-												</small>
-												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeItalics('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Italicize">
-												<i class="fas fa-italic" aria-hidden="true"></i>
-												</small>
-												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeQuote('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quote">
-												<i class="fas fa-quote-right" aria-hidden="true"></i>
-												</small>
-												<small class="btn btn-secondary format d-inline-block m-0" onclick="makeLink('post-text')" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Link">
-													<i class="fas fa-link" aria-hidden="true"></i>
-												</small>
-												<label class="format btn btn-secondary m-0 {% if v %}d-inline-block{% else %}d-none{% endif %}" for="file-upload-submit">
-													<div id="filename-show-submit"><i class="far fa-image"></i></div>
-													<input autocomplete="off" id="file-upload-submit" multiple="multiple" type="file" name="file2" accept="image/*" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} onchange="changename('filename-show-submit','file-upload-submit');checkForRequired()" hidden>
-												</label>	
-
-												<div id="preview" class="preview my-3"></div>
-
-												<pre></pre>
-												<div class="form-text text-small"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
-												<pre></pre>
-
-												<div class="custom-control custom-checkbox">
-														<input checked autocomplete="off" type="checkbox" class="custom-control-input" id="followers" name="followers">
-														<label class="custom-control-label" for="followers">Notify followers</label>
-												</div>
-
-												<div class="custom-control custom-checkbox">
-														<input autocomplete="off" type="checkbox" class="custom-control-input" id="nsfw" name="over_18">
-														<label class="custom-control-label" for="nsfw">18+</label>
-												</div>
-												<div class="custom-control custom-checkbox">
-														<input onchange='draft(this);' autocomplete="off" type="checkbox" class="custom-control-input" id="private" name="private">
-														<label class="custom-control-label" for="private">Draft</label>
-												</div>
-
-												<pre>
-
-
-
-
-
-
-												</pre>
-										</div>
+								<div id="urlblock">
+										<label for="URL" class="mt-3">URL</label>
+										<input autocomplete="off" class="form-control" id="post-url" aria-describedby="URLHelp" name="url" type="url" placeholder="Optional if you have text." value="{{request.values.get('url','')}}" maxlength="2048" required oninput="checkForRequired();hide_image();savetext();checkRepost(this);autoSuggestTitle()">
+										<small id="system" class="form-text text-muted">To post an image, use a direct image link such as i.imgur.com</small>
 								</div>
+								<div id="image-upload-block">
+									<div><label class="mt-3">Attachment Upload</label></div>
+
+									<img loading="lazy" id="image-preview" style="max-width:50%">
+									<label class="btn btn-secondary m-0" for="file-upload">
+										<div id="filename-show">Select File</div>
+										<input autocomplete="off" id="file-upload" type="file" name="file" {% if request.headers.get('cf-ipcountry')=="T1" %}disabled{% endif %} accept="image/*" hidden>
+									</label>
+									<small class="form-text text-muted">Optional if you have text.</small>
+									<small class="form-text text-muted">You can upload images or videos up to 60 seconds.</small>
+								</div>
+
+								<label for="body" class="mt-3">Text<i class="fas fa-info-circle text-gray-400 ml-1" data-bs-toggle="tooltip" data-bs-placement="top" title="Uses markdown. Limited to {{SUBMISSION_BODY_LENGTH_MAXIMUM}} characters."></i></label>
+
+								<div>
+									<textarea form="submitform" id="post-text" class="form-control rounded" aria-label="With textarea" placeholder="Optional if you have a link or an image." rows="7" name="body" oninput="markdown(this);charLimit(this);checkForRequired();savetext()" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" required></textarea>
+
+									<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+
+									<div class="d-flex justify-content-between">
+										{% from "component/comment/_editor_buttons.html" import editor_buttons %}
+										{{ editor_buttons('submit', 'post-text') }}
+
+										<a role="button" class="btn btn-secondary mt-2" onclick="document.getElementById('preview').classList.toggle('d-none');">
+											Toggle preview
+										</a>
+									</div>
+								</div>
+
+								<div id="preview" class="preview my-3"></div>
+
+								<pre></pre>
+								<div class="form-text text-small"><a href="/formatting" {% if v and v.newtab and not g.webview %}target="_blank"{% endif %}>Formatting help</a></div>
+								<pre></pre>
+
+								<div class="custom-control custom-checkbox">
+										<input checked autocomplete="off" type="checkbox" class="custom-control-input" id="followers" name="followers">
+										<label class="custom-control-label" for="followers">Notify followers</label>
+								</div>
+
+								<div class="custom-control custom-checkbox">
+										<input autocomplete="off" type="checkbox" class="custom-control-input" id="nsfw" name="over_18">
+										<label class="custom-control-label" for="nsfw">18+</label>
+								</div>
+								<div class="custom-control custom-checkbox">
+										<input onchange='draft(this);' autocomplete="off" type="checkbox" class="custom-control-input" id="private" name="private">
+										<label class="custom-control-label" for="private">Draft</label>
+								</div>
+
+								<pre>
+
+
+
+
+
+
+								</pre>
+							</div>
 						</div>
+					</div>
+				</div>
 				<div class="container">
-						<div class="row fixed-bottom bg-white border-top p-3" id="" style="z-index: 100; bottom: 0px; transition: bottom 220ms cubic-bezier(0, 0, 0.2, 1) 0s;">
-								<div class="col">
-										<a href="/" class="btn btn-secondary">Cancel</a>
-								</div>
-								<div class="col text-right">
-										{% if error %}<span class="text-danger text-large mr-2">{{error}}</span>{% endif %}
-										<button class="btn btn-primary" id="create_button" type="submit" disabled>Post</button>
-								</div>
+					<div class="row fixed-bottom bg-white border-top p-3" id="" style="z-index: 100; bottom: 0px; transition: bottom 220ms cubic-bezier(0, 0, 0.2, 1) 0s;">
+						<div class="col">
+							<a href="/" class="btn btn-secondary">Cancel</a>
 						</div>
+						<div class="col text-right">
+							{% if error %}<span class="text-danger text-large mr-2">{{error}}</span>{% endif %}
+							<button class="btn btn-primary" id="create_button" type="submit" disabled>Post</button>
+						</div>
+					</div>
 				</div>
 			</form>
 		</div>
-		{% endblock %}
+	{% endblock %}
 
-		<script src="{{ 'js/vendor/purify.min.js' | asset }}"></script>
-		<script src="{{ 'js/vendor/marked.min.js' | asset }}"></script>
-		<script src="{{ 'js/marked.custom.js' | asset }}"></script>
-		<script src="{{ 'js/formatting.js' | asset }}"></script>
-		<script src="{{ 'js/submit.js' | asset }}"></script>
+	<script src="{{ 'js/vendor/purify.min.js' | asset }}"></script>
+	<script src="{{ 'js/vendor/marked.min.js' | asset }}"></script>
+	<script src="{{ 'js/marked.custom.js' | asset }}"></script>
+	<script src="{{ 'js/formatting.js' | asset }}"></script>
+	<script src="{{ 'js/submit.js' | asset }}"></script>
 </body>
 </html>

--- a/files/templates/submit.html
+++ b/files/templates/submit.html
@@ -65,13 +65,13 @@
 												<label for="body" class="mt-3">Text<i class="fas fa-info-circle text-gray-400 ml-1" data-bs-toggle="tooltip" data-bs-placement="top" title="Uses markdown. Limited to {{SUBMISSION_BODY_LENGTH_MAXIMUM}} characters."></i></label>
 
 												<div>
-													<textarea form="submitform" id="post-text" class="form-control rounded" aria-label="With textarea" placeholder="Optional if you have a link or an image." rows="7" name="body" oninput="markdown(this);charLimit('post-text','character-count-submit-text-form');checkForRequired();savetext()" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" required></textarea>
+													<textarea form="submitform" id="post-text" class="form-control rounded" aria-label="With textarea" placeholder="Optional if you have a link or an image." rows="7" name="body" oninput="markdown(this);charLimit(this);checkForRequired();savetext()" maxlength="{{SUBMISSION_BODY_LENGTH_MAXIMUM}}" required></textarea>
 
 													<div class="btn btn-secondary fl-r mt-3" onclick="document.getElementById('preview').classList.toggle('d-none');">
 														Toggle preview
 													</div>
 
-													<div class="text-small font-weight-bold mt-1" id="character-count-submit-text-form" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
+													<div class="charcount text-small font-weight-bold mt-1" style="right: 1rem; bottom: 0.5rem; z-index: 3;"></div>
 
 												</div>
 


### PR DESCRIPTION
# Description

While working on #776, I've noticed a serious repetition problem with post forms. Very similar code is quadrupled, in some cases sextupled (make/edit comment, make/edit post, profile description).

* Moved the buttons of most of the editors to a common Jinja macro.
* Streamlined some of the ids, so that the pasting image function doesn't need to do the same thing three times.
* Likewise, simplified `markdown` and `charCount` functions so that they don't need bespoke ids as parameters.
* While doing that I've noticed that preview and count is not initialized immediately while clicking "edit", so I fixed that.

# Possible TODOs

* [x] The form for making a post has a slightly different markup, but it still should be made to use same buttons as the other ones
* [ ] A comment in markdown function mentions #139 - should the Image button be removed for now?
* [ ] some tests on the frontend would be nice I guess
* [ ] consider the following scenario: you click "edit", change the text a bit, then click "cancel", then "edit" again - should the text in form reflect your changes, or be reset?