### PR TITLE
Fix/test runner timing fix

### DIFF
--- a/files/tests/test_lazy_load_reporter.py
+++ b/files/tests/test_lazy_load_reporter.py
@@ -7,8 +7,8 @@ from sqlalchemy import event
 from sqlalchemy.orm import Session
 
 from files import __main__ as main
-from files.__main__ import LazyLoadReporter, db_session
-from files.classes import Submission, User
+from files.__main__ import LazyLoadReporter
+from files.classes import Submission
 
 from . import util_accounts, util
 
@@ -18,8 +18,8 @@ pytestmark = pytest.mark.filterwarnings(
 
 
 def _trigger_lazy_load():
-	"""Create a fresh submission, reload it from the session, then access
-	.author after expiring that relationship to force a lazy load."""
+	"""Create a fresh submission, reload it in an isolated session, then
+	access .author after expiring that relationship to force a lazy load."""
 	client, _ = util_accounts.create_test_client_and_user()
 	response, _ = util.post_with_formkey(
 		client, "/submit",
@@ -28,10 +28,13 @@ def _trigger_lazy_load():
 	assert response.status_code == 200
 
 	post = util.ItemData.from_html(response.text)
-	db_session.expunge_all()
-	sub = db_session.get(Submission, post.id)
-	db_session.expire(sub, ['author'])
-	_ = sub.author
+	session = main.db_session_factory()
+	try:
+		sub = session.get(Submission, post.id)
+		session.expire(sub, ['author'])
+		_ = sub.author
+	finally:
+		session.close()
 
 
 def _set_global_reporter_enabled(enabled: bool):

--- a/files/tests/test_lazy_load_reporter.py
+++ b/files/tests/test_lazy_load_reporter.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import event
 from sqlalchemy.orm import Session
 
+from files import __main__ as main
 from files.__main__ import LazyLoadReporter, db_session
 from files.classes import Submission, User
 
@@ -17,19 +18,37 @@ pytestmark = pytest.mark.filterwarnings(
 
 
 def _trigger_lazy_load():
-	"""Load any Submission, expire its author, then access it to force a
-	lazy load on Submission.author.  Uses a direct ORM query so it doesn't
-	depend on any particular route's eager-loading behavior."""
-	sub = db_session.query(Submission).first()
-	if sub is None:
-		client, _ = util_accounts.create_test_client_and_user()
-		util.post_with_formkey(
-			client, "/submit",
-			data={"title": util.generate_text(), "body": util.generate_text()},
-		)
-		sub = db_session.query(Submission).first()
+	"""Create a fresh submission, reload it from the session, then access
+	.author after expiring that relationship to force a lazy load."""
+	client, _ = util_accounts.create_test_client_and_user()
+	response, _ = util.post_with_formkey(
+		client, "/submit",
+		data={"title": util.generate_text(), "body": util.generate_text()},
+	)
+	assert response.status_code == 200
+
+	post = util.ItemData.from_html(response.text)
+	db_session.expunge_all()
+	sub = db_session.get(Submission, post.id)
 	db_session.expire(sub, ['author'])
 	_ = sub.author
+
+
+def _set_global_reporter_enabled(enabled: bool):
+	"""Temporarily disable the app-level reporter so tests only observe
+	the reporter instance they register themselves."""
+	reporter = getattr(main, "_lazy_load_reporter", None)
+	if reporter is None:
+		return None
+
+	listener = reporter.on_orm_execute
+	is_registered = event.contains(Session, "do_orm_execute", listener)
+	if enabled and not is_registered:
+		event.listen(Session, "do_orm_execute", listener)
+	elif not enabled and is_registered:
+		event.remove(Session, "do_orm_execute", listener)
+
+	return is_registered
 
 
 def test_reports_lazy_load_with_field_name():
@@ -38,6 +57,7 @@ def test_reports_lazy_load_with_field_name():
 	reporter = LazyLoadReporter(interval=0)
 	listener = reporter.on_orm_execute
 	event.listen(Session, "do_orm_execute", listener)
+	global_reporter_was_enabled = _set_global_reporter_enabled(False)
 	try:
 		buf = io.StringIO()
 		with redirect_stderr(buf):
@@ -48,6 +68,8 @@ def test_reports_lazy_load_with_field_name():
 		assert re.search(r"\[lazy-load\] \w+\.\w+", output), \
 			f"Expected Class.field format in: {output}"
 	finally:
+		if global_reporter_was_enabled:
+			_set_global_reporter_enabled(True)
 		event.remove(Session, "do_orm_execute", listener)
 
 
@@ -57,6 +79,7 @@ def test_suppresses_within_interval():
 	reporter = LazyLoadReporter(interval=9999)
 	listener = reporter.on_orm_execute
 	event.listen(Session, "do_orm_execute", listener)
+	global_reporter_was_enabled = _set_global_reporter_enabled(False)
 	try:
 		buf = io.StringIO()
 		with redirect_stderr(buf):
@@ -69,6 +92,8 @@ def test_suppresses_within_interval():
 		assert len(lines) == 1, f"Expected 1 report, got {len(lines)}: {lines}"
 		assert reporter._suppressed >= 1
 	finally:
+		if global_reporter_was_enabled:
+			_set_global_reporter_enabled(True)
 		event.remove(Session, "do_orm_execute", listener)
 
 
@@ -78,6 +103,7 @@ def test_reports_suppressed_count():
 	reporter = LazyLoadReporter(interval=0)
 	listener = reporter.on_orm_execute
 	event.listen(Session, "do_orm_execute", listener)
+	global_reporter_was_enabled = _set_global_reporter_enabled(False)
 	try:
 		# First: fill up suppressed count by using a long interval
 		reporter.interval = 9999
@@ -93,4 +119,6 @@ def test_reports_suppressed_count():
 		output = buf.getvalue()
 		assert "unreported since last" in output
 	finally:
+		if global_reporter_was_enabled:
+			_set_global_reporter_enabled(True)
 		event.remove(Session, "do_orm_execute", listener)

--- a/util/common/__init__.py
+++ b/util/common/__init__.py
@@ -39,8 +39,8 @@ def _execute(command,**kwargs):
             print(stderr)
             
             raise subprocess.CalledProcessError(
-                    command,
                     proc.returncode,
+                    command,
                     stdout or None,
                     stderr or None
             )


### PR DESCRIPTION
This is a fix for all those `files/tests/test_lazy_load_reporter.py::test_suppresses_within_interval` failures.

---

Temporarily disable the app-level lazy load reporter while the reporter tests run so the tests only observe the listener they register themselves. This avoids intermittent failures caused by the process-global reporter sometimes emitting an extra [lazy-load] line depending on prior test timing.

Also fix util/common to construct CalledProcessError with the correct argument order so test command failures print a usable exception instead of <exception str() failed>.